### PR TITLE
Fix invisible name for legendary tokens

### DIFF
--- a/magic-m15-mainframe-tokens.mse-style/style
+++ b/magic-m15-mainframe-tokens.mse-style/style
@@ -597,7 +597,7 @@ extra card style:
 		top: 0
 		width: 375
 		height: 523
-		z index: 3
+		z index: 0
 		render style: image
 		visible: {is_legend()}
 		image: {"crown" + (if is_m20() then "_m20") + ".png"}


### PR DESCRIPTION
The legend crown was in front of the name. Fixed by reducing the z-index for the crown, not sure if that breaks anything else.