### PR TITLE
New blends Functionality Addition: Mod Colors

### DIFF
--- a/magic-blends.mse-include/mask_names.txt
+++ b/magic-blends.mse-include/mask_names.txt
@@ -1,0 +1,11 @@
+id_mask:= [	
+		32:	"/magic-identity-new.mse-include/imask_32.png"
+		33:	"/magic-identity-new.mse-include/imask_33.png"
+		42:	"/magic-identity-new.mse-include/imask_42.png"
+		43:	"/magic-identity-new.mse-include/imask_43.png"
+		44:	"/magic-identity-new.mse-include/imask_44.png"
+		52:	"/magic-identity-new.mse-include/imask_52.png"
+		53:	"/magic-identity-new.mse-include/imask_53.png"
+		54:	"/magic-identity-new.mse-include/imask_54.png"
+		55:	"/magic-identity-new.mse-include/imask_55.png"
+]

--- a/magic-blends.mse-include/new-blends
+++ b/magic-blends.mse-include/new-blends
@@ -6,248 +6,269 @@
 # Filenames and other defaults
 ########################################################################
 
-mask_hybrid_with_land	:= { false }
-mask_hybrid_with_gold	:= { false }
-mask_multi_land_with_color	:= { false }
-template		:= { input + "{type}.jpg" }
-land_template		:= { (if input == "a" then "c" else input) + "l{type}.jpg" }
+	mask_hybrid_with_land			:=	{ false }
+	mask_hybrid_with_gold			:=	{ false }
+	mask_multi_land_with_color		:=	{ false }
+	template						:=	{		input								+  "{type}.jpg" }
+	land_template					:=	{ (if	input == "a" then "c" else input)	+ "l{type}.jpg" }
+
 # For what value should thumbnails of hybrids be made?
-hybrid_previews         := "hybrid"
+	hybrid_previews					:= "hybrid"
+
 # Are there templates for colored lands, land_template(...)?
-colored_lands           := true
-trim_colors :=
-	replace@(match:"(, )?(multicolor|hybrid|artifact|land|horizontal|vertical|radial)", replace:"")
-watermark_colors := {
-	if trim_colors(card.card_color) == "white" then "ww"
-	else if trim_colors(card.card_color) == "blue" then "uu"
-	else if trim_colors(card.card_color) == "black" then "bb"
-	else if trim_colors(card.card_color) == "red" then "rr"
-	else if trim_colors(card.card_color) == "green" then "gg"
-	else if contains(card.card_color, match:"multi") or contains(card.card_color, match:"hybrid") or contains(card.card_color, match:", land") then hybrid_color()
-	else if contains(card.card_color, match:"artifact") then "aa"
-	else "cc"
+	colored_lands					:= true
+	trim_colors						:=
+		replace@(match:"(, )?(multicolor|hybrid|artifact|land|horizontal|vertical|radial)", replace:"")
+
+	watermark_colors := {
+		if		trim_colors(card.card_color) == "white"		then	"ww"
+		else if trim_colors(card.card_color) == "blue"		then	"uu"
+		else if trim_colors(card.card_color) == "black"		then	"bb"
+		else if trim_colors(card.card_color) == "red"		then	"rr"
+		else if trim_colors(card.card_color) == "green"		then	"gg"
+		else if contains(card.card_color, match:"multi")	or
+				contains(card.card_color, match:"hybrid")	or
+				contains(card.card_color, match:", land")	then	hybrid_color()
+		else if contains(card.card_color, match:"artifact") then	"aa"
+		else														"cc"
 }
 hybrid_color := {
-	if trim_colors(card.card_color) == "white, blue" then "wu"
-	else if trim_colors(card.card_color) == "white, black" then "wb"
-	else if trim_colors(card.card_color) == "white, red" then "rw"
-	else if trim_colors(card.card_color) == "white, green" then "gw"
-	else if trim_colors(card.card_color) == "blue, black" then "ub"
-	else if trim_colors(card.card_color) == "blue, red" then "ur"
-	else if trim_colors(card.card_color) == "blue, green" then "gu"
-	else if trim_colors(card.card_color) == "black, red" then "br"
-	else if trim_colors(card.card_color) == "black, green" then "bg"
-	else if trim_colors(card.card_color) == "red, green" then "rg"
-	else if trim_colors(card.card_color) == "white, blue, reversed" then "uw"
-	else if trim_colors(card.card_color) == "white, black, reversed" then "bw"
-	else if trim_colors(card.card_color) == "white, red, reversed" then "wr"
-	else if trim_colors(card.card_color) == "white, green, reversed" then "wg"
-	else if trim_colors(card.card_color) == "blue, black, reversed" then "bu"
-	else if trim_colors(card.card_color) == "blue, red, reversed" then "ru"
-	else if trim_colors(card.card_color) == "blue, green, reversed" then "ug"
-	else if trim_colors(card.card_color) == "black, red, reversed" then "rb"
-	else if trim_colors(card.card_color) == "black, green, reversed" then "bg"
-	else if trim_colors(card.card_color) == "red, green, reversed" then "gr"
-	else "mm"
+	if 		trim_colors(card.card_color) == "white,	blue"				then "wu"
+	else if trim_colors(card.card_color) == "white,	black"				then "wb"
+	else if trim_colors(card.card_color) == "white,	red"				then "rw"
+	else if trim_colors(card.card_color) == "white,	green"				then "gw"
+	else if trim_colors(card.card_color) == "blue,	black"				then "ub"
+	else if trim_colors(card.card_color) == "blue,	red"				then "ur"
+	else if trim_colors(card.card_color) == "blue,	green"				then "gu"
+	else if trim_colors(card.card_color) == "black,	red"				then "br"
+	else if trim_colors(card.card_color) == "black,	green"				then "bg"
+	else if trim_colors(card.card_color) == "red,	green"				then "rg"
+	else if trim_colors(card.card_color) == "white,	blue,	reversed"	then "uw"
+	else if trim_colors(card.card_color) == "white,	black,	reversed"	then "bw"
+	else if trim_colors(card.card_color) == "white,	red,	reversed"	then "wr"
+	else if trim_colors(card.card_color) == "white,	green,	reversed"	then "wg"
+	else if trim_colors(card.card_color) == "blue,	black,	reversed"	then "bu"
+	else if trim_colors(card.card_color) == "blue,	red,	reversed"	then "ru"
+	else if trim_colors(card.card_color) == "blue,	green,	reversed"	then "ug"
+	else if trim_colors(card.card_color) == "black,	red,	reversed"	then "rb"
+	else if trim_colors(card.card_color) == "black,	green,	reversed"	then "bg"
+	else if trim_colors(card.card_color) == "red,	green,	reversed"	then "gr"
+	else																	 "mm"
 }
 ########################################################################
 # Combining multiple colors (hybrids)
 ########################################################################
 
-card_hybrid_2 := {
-	linear_blend(
-		image1: template(colors[0])
-		image2: template(colors[1])
-		x1: 0.4,  y1: 0
-		x2: 0.6,  y2: 0
+card_hybrid_2 := {linear_blend(
+					image1:					template(						colors[0])
+					image2:					template(						colors[1])
+												x1: 0.4,		y1: 0
+												x2: 0.6,		y2: 0
 	)
 }
 
 overlay_hybrid := [
-	1: { template(colors[0]) }
-	2: { combine_blend(
-		image1: template(colors[0]),
-		image2: template(colors[1]),
-		combine: "symmetric overlay"
-	   )}
+	1: {									template(						colors[0])}
+	2: {combine_blend(
+			image1: 						template(						colors[0]),
+			image2: 						template(						colors[1]),
+			combine: "symmetric overlay"
+	)}
 ]
 
+
 # vertical version of a horizontal hybrid
-vertical_card_hybrid := {
-	do_linear_blend := linear_blend
-	linear_blend := { do_linear_blend(x1: 0, x2: 0, y1: x1, y2: x2) }
+vertical_card_hybrid	:= {
+	do_linear_blend			:=	  linear_blend
+	linear_blend			:=	{ do_linear_blend(x1: 0, x2: 0, y1: x1, y2: x2) }
 	card_hybrid.horizontal[color_count]()
 }
 
+
 horizontal_card_hybrid := [
-	1: { template(colors[0]) }
-	2: card_hybrid_2
+	1:	{ 									template(						colors[0])
+	}
+
+	2:	card_hybrid_2
+
 	3: {linear_blend(
-		image1: template(colors[0])
-		x1: 0.22,  y1: 0
-		x2: 0.4,   y2: 0
-		image2: linear_blend(
-		  image1: template(colors[1])
-		  x1: 0.6,   y1: 0
-		  x2: 0.78,  y2: 0
-		  image2: template(colors[2])
-	   ))}
+			image1:							template(						colors[0])
+												x1: 0.22,		y1: 0
+												x2: 0.4,		y2: 0
+			image2: linear_blend(
+				image1:						template(						colors[1])
+												x1: 0.6,		y1: 0
+												x2: 0.78,		y2: 0
+				image2: 					template(						colors[2])
+	))}
+
 	4: {linear_blend(
-		# blend = 0.16
-		image1: template(colors[0])
-		x1: 0.15,  y1: 0
-		x2: 0.31,  y2: 0
-		image2: linear_blend(
-		  image1: template(colors[1])
-		  x1: 0.42,  y1: 0
-		  x2: 0.58,  y2: 0
-		  image2: linear_blend(
-		    image1: template(colors[2])
-		    x1: 0.69, y1: 0
-		    x2: 0.85, y2: 0
-		    image2: template(colors[3])
-	   )))}
+			image1:							template(						colors[0])
+												x1: 0.15,		y1: 0
+												x2: 0.31,		y2: 0
+			image2: linear_blend(
+				image1:						template(						colors[1])
+												x1: 0.42,		y1: 0
+												x2: 0.58,		y2: 0
+				image2: linear_blend(
+					image1:					template(						colors[2])
+												x1: 0.69,		y1: 0
+												x2: 0.85,		y2: 0
+					image2:					template(						colors[3])
+	)))}
+
 	5: {linear_blend(
-		image1: template(colors[0])
-		x1: 2.0 / 15,  y1: 0
-		x2: 4.0 / 15,  y2: 0
-		image2: linear_blend(
-		  image1: template(colors[1])
-		  x1: 5.0 / 15,  y1: 0
-		  x2: 7.0 / 15,  y2: 0
-		  image2: linear_blend(
-		    image1: template(colors[2])
-		    x1:  8.0 / 15,  y1: 0
-		    x2: 10.0 / 15,  y2: 0
-		    image2: linear_blend(
-		      image1: template(colors[3])
-		      x1: 11.0 / 15,  y1: 0
-		      x2: 13.0 / 15,  y2: 0
-		      image2: template(colors[4])
-	   ))))}
+			image1: 						template(						colors[0])
+												x1:  2.0 / 15,	y1: 0
+												x2:  4.0 / 15,	y2: 0
+			image2: linear_blend(
+				image1: 					template(						colors[1])
+												x1:  5.0 / 15,	y1: 0
+												x2:  7.0 / 15,	y2: 0
+				image2: linear_blend(
+					image1: 				template(						colors[2])
+												x1:  8.0 / 15,	y1: 0
+												x2: 10.0 / 15,	y2: 0
+					image2: linear_blend(
+						image1:				template(						colors[3])
+												x1: 11.0 / 15,	y1: 0
+												x2: 13.0 / 15,	y2: 0
+						image2:				template(						colors[4])
+	))))}
+
 	6: {linear_blend(
-		image1: template(colors[0])
-		x1: 1.5 / 15,  y1: 0
-		x2: 3.1 / 15,  y2: 0
-		image2: linear_blend(
-		  image1: template(colors[1])
-		  x1: 4.1 / 15,  y1: 0
-		  x2: 5.7 / 15,  y2: 0
-		  image2: linear_blend(
-		    image1: template(colors[2])
-		    x1: 6.7 / 15,  y1: 0
-		    x2: 8.3 / 15,  y2: 0
-		    image2: linear_blend(
-		      image1: template(colors[3])
-		      x1: 9.3 / 15,  y1: 0
-		      x2: 10.9 / 15,  y2: 0
-		      image2: linear_blend(
-		        image1: template(colors[4])
-		        x1: 11.9 / 15, y1: 0
-		        x2: 13.5 / 15, y2: 0
-		        image2: template(colors[5])
-	   )))))}
+			image1:							template(						colors[0])
+												x1:  1.5 / 15,	y1: 0
+												x2:  3.1 / 15,	y2: 0
+			image2: linear_blend(
+				image1:						template(						colors[1])
+												x1:  4.1 / 15,	y1: 0
+												x2:  5.7 / 15,	y2: 0
+				image2: linear_blend(
+					image1:					template(						colors[2])
+												x1:  6.7 / 15,	y1: 0
+												x2:  8.3 / 15,	y2: 0
+					image2: linear_blend(
+						image1:				template(						colors[3])
+												x1:  9.3 / 15,	y1: 0
+												x2: 10.9 / 15,	y2: 0
+						image2: linear_blend(
+							image1:			template(						colors[4])
+												x1: 11.9 / 15,	y1: 0
+												x2: 13.5 / 15,	y2: 0
+							image2:			template(						colors[5])
+	)))))}
+
 	7: {linear_blend(
-		image1: template(colors[0])
-		x1: 1.3 / 15,  y1: 0
-		x2: 2.7 / 15,  y2: 0
-		image2: linear_blend(
-		  image1: template(colors[1])
-		  x1: 3.5 / 15,  y1: 0
-		  x2: 4.9 / 15,  y2: 0
-		  image2: linear_blend(
-		    image1: template(colors[2])
-		    x1: 5.7 / 15,  y1: 0
-		    x2: 7.1 / 15,  y2: 0
-		    image2: linear_blend(
-		      image1: template(colors[3])
-		      x1: 7.9 / 15,  y1: 0
-		      x2: 9.3 / 15,  y2: 0
-		      image2: linear_blend(
-		        image1: template(colors[4])
-		        x1: 10.1 / 15, y1: 0
-		        x2: 11.5 / 15, y2: 0
-		        image2: linear_blend(
-		          image1: template(colors[5])
-		          x1: 12.3 / 15, y1: 0
-		          x2: 13.7 / 15, y2: 0
-		          image2: template(colors[6])
-	   ))))))}
+			image1:							template(						colors[0])
+												x1:  1.3 / 15,	y1: 0
+												x2:  2.7 / 15,	y2: 0
+			image2: linear_blend(
+				image1:						template(						colors[1])
+												x1:  3.5 / 15,	y1: 0
+												x2:  4.9 / 15,	y2: 0
+				image2: linear_blend(
+					image1:					template(						colors[2])
+												x1:  5.7 / 15,	y1: 0
+												x2:  7.1 / 15,	y2: 0
+					image2: linear_blend(
+						image1:				template(						colors[3])
+												x1:  7.9 / 15,	y1: 0
+												x2:  9.3 / 15,	y2: 0
+						image2: linear_blend(
+							image1:			template(						colors[4])
+												x1: 10.1 / 15,	y1: 0
+												x2: 11.5 / 15,	y2: 0
+							image2: linear_blend(
+								image1:		template(						colors[5])
+												x1: 12.3 / 15,	y1: 0
+												x2: 13.7 / 15,	y2: 0
+								image2:		template(						colors[6])
+		))))))}
 ]
+
 
 card_hybrid := [
 	radial: [
-		0: { template("c") }
-		1: { template(colors[0]) }
-		2: card_hybrid_2
-		3: {linear_blend(
-			image1: card_hybrid_2(colors: colors[0] + colors[1]),
-			image2: template(colors[2]),
-			x1: 0,  y1: 0.55
-			x2: 0,  y2: 0.77
-		   )}
-		4: {linear_blend(
-			image1: card_hybrid_2(colors: colors[0] + colors[1])
-			image2: card_hybrid_2(colors: colors[3] + colors[2])
-			x1: 0,  y1: 0.4
-			x2: 0,  y2: 0.62
-		   )}
+		0: {								template(						"c") }
+
+		1: {								template(						colors[0]) }
+
+		2:	card_hybrid_2
+
+		3:{linear_blend(
+			image1: 						card_hybrid_2(					colors: colors[0] + colors[1]),
+			image2: 						template(						colors[2]),
+												x1: 0,			y1: 0.55
+												x2: 0,			y2: 0.77
+		)}
+
+		4:{linear_blend(
+			image1:							card_hybrid_2(					colors: colors[0] + colors[1])
+			image2: 						card_hybrid_2(					colors: colors[3] + colors[2])
+												x1: 0,			y1: 0.4
+												x2: 0,			y2: 0.62
+		)}
+
 		5: {linear_blend(
-			image1: linear_blend(
-				image1: card_hybrid_2(colors: colors[0] + colors[1]),
-				image2: card_hybrid_2(colors: colors[4] + colors[2]),
-				x1: 0,  y1: 0.19
-				x2: 0,  y2: 0.35
-			),
-			image2: template(colors[3]),
-			x1: 0,  y1: 0.777
-			x2: 0,  y2: 0.937
-		   )}
-		6: {linear_blend(
-			image1: linear_blend(
-				image1: card_hybrid_2(colors: colors[0] + colors[1]),
-				image2: card_hybrid_2(colors: colors[5] + colors[2]),
-				x1: 0,  y1: 0.19
-				x2: 0,  y2: 0.35
-			),
-			image2: card_hybrid_2(colors: colors[4] + colors[3]),
-			x1: 0,  y1: 0.777
-			x2: 0,  y2: 0.937
-		   )}
-		7: {linear_blend(
-			image1: linear_blend(
 				image1: linear_blend(
-					image1: card_hybrid_2(colors: colors[0] + colors[1]),
-					image2: card_hybrid_2(colors: colors[6] + colors[3]),
-					x1: 0,  y1: 0.34
-					x2: 0,  y2: 0.50
-				),
-				image2: card_hybrid_2(colors: colors[5] + colors[3]),
-				x1: 0,  y1: 0.877
-				x2: 0,  y2: 0.937
+					image1:					card_hybrid_2(					colors: colors[0] + colors[1]),
+					image2:					card_hybrid_2(					colors: colors[4] + colors[2]),
+												x1: 0,			y1: 0.19
+												x2: 0,			y2: 0.35
 			),
-			image2: template(colors[4]),
-			x1: 0,  y1: 1.140
-			x2: 0,  y2: 1.300
+				image2:						template(colors[3]),
+												x1: 0,			y1: 0.777
+												x2: 0,			y2: 0.937
+		)}
+
+		6: {linear_blend(
+				image1: linear_blend(
+					image1:					card_hybrid_2(					colors: colors[0] + colors[1]),
+					image2:					card_hybrid_2(					colors: colors[5] + colors[2]),
+												x1: 0,			y1: 0.19
+												x2: 0,			y2: 0.35
+				),
+				image2:						card_hybrid_2(					colors: colors[4] + colors[3]),
+												x1: 0,			y1: 0.777
+												x2: 0,			y2: 0.937
+		)}
+
+		7: {linear_blend(
+				image1: linear_blend(
+					image1: linear_blend(
+						image1:				card_hybrid_2(					colors: colors[0] + colors[1]),
+						image2:				card_hybrid_2(					colors: colors[6] + colors[3]),
+												x1: 0,			y1: 0.34
+												x2: 0,			y2: 0.50
+					),
+					image2:					card_hybrid_2(					colors: colors[5] + colors[3]),
+												x1: 0,			y1: 0.877
+												x2: 0,			y2: 0.937
+				),
+				image2:						template(						colors[4]),
+												x1: 0,			y1: 1.140
+												x2: 0,			y2: 1.300
 		   )}
 	]
-	horizontal: horizontal_card_hybrid
-	vertical: [
-		1: { template(colors[0]) }
+	horizontal:		horizontal_card_hybrid
+	vertical:		[
+		1: { 								template(						colors[0]) }
 		2: { linear_blend(
-			image1: template(colors[0])
-			image2: template(colors[1])
-			x1: 0,  y1: 0.4
-			x2: 0,  y2: 0.6
-		   )}
-		3: vertical_card_hybrid
-		4: vertical_card_hybrid
-		5: vertical_card_hybrid
-		6: vertical_card_hybrid
-		7: vertical_card_hybrid
+				image1:						template(						colors[0])
+				image2:						template(						colors[1])
+												x1: 0,			y1: 0.4
+												x2: 0,			y2: 0.6
+		)}
+		3:			vertical_card_hybrid
+		4:			vertical_card_hybrid
+		5:			vertical_card_hybrid
+		6:			vertical_card_hybrid
+		7:			vertical_card_hybrid
 	]
-	overlay: overlay_hybrid
+	overlay:		overlay_hybrid
 ]
+
 
 
 ########################################################################
@@ -256,75 +277,76 @@ card_hybrid := [
 # These are easier
 
 horizontal_pt_hybrid := [
-	1: { template(colors[0]) }
-	2: { template(colors[1]) }
+	1: {									template(						colors[0]) }
+	2: {									template(						colors[1]) }
 	3: { linear_blend(
-		image1: template(colors[1])
-		image2: template(colors[2])
-		x1: -0.51, y1: 0
-		x2:  0.26, y2: 0
+			image1:							template(						colors[1])
+			image2:							template(						colors[2])
+												x1: -0.51,		y1: 0
+												x2:  0.26,		y2: 0
 	   )}
 	4: { linear_blend(
-		image1: template(colors[2])
-		image2: template(colors[3])
-		x1: -0.1,  y1: 0
-		x2:  0.6,  y2: 0
+			image1:							template(						colors[2])
+			image2:							template(						colors[3])
+												x1: -0.1,		y1: 0
+												x2:  0.6,		y2: 0
 	   )}
 	5: { linear_blend(
-		image1: template(colors[3])
-		image2: template(colors[4])
-		x1: 0.08,  y1: 0
-		x2: 0.65,  y2: 0
+			image1:							template(						colors[3])
+			image2:							template(						colors[4])
+												x1: 0.08,		y1: 0
+												x2: 0.65,		y2: 0
 	   )}
 	6: { linear_blend(
-		image1: template(colors[4])
-		image2: template(colors[5])
-		x1: 0.07, y1: 0
-		x2: 0.7, y2: 0
+			image1:							template(						colors[4])
+			image2:							template(						colors[5])
+												x1: 0.07,		y1: 0
+												x2: 0.7,		y2: 0
 	   )}
 	7: {linear_blend(
-		image1: linear_blend(
-			image1: template(colors[4]),
-			image2: template(colors[5]),
-			x1: -0.2,  y1: 0
-			x2: 0.2,  y2: 0
-		),
-		image2: template(colors[6]),
-		x1: 0.5,  y1: 0
-		x2: 0.7,  y2: 0
-	   )}
+			image1: linear_blend(
+				image1:						template(						colors[4]),
+				image2:						template(						colors[5]),
+												x1: -0.2,		y1: 0
+												x2:  0.2,		y2: 0
+			),
+			image2:							template(						colors[6]),
+												x1: 0.5,		y1: 0
+												x2: 0.7,		y2: 0
+	)}
 ]
+
 
 pt_hybrid := [
 	radial: [
-		0: { template("c")       }
-		1: { template(colors[0]) }
-		2: { template(colors[1]) }
-		3: { template(colors[2]) }
-		4: { template(colors[2]) }
+		0: {								template(						"c")		}
+		1: {								template(						colors[0])	}
+		2: {								template(						colors[1])	}
+		3: {								template(						colors[2])	}
+		4: {								template(						colors[2])	}
 		5: { linear_blend(
-			image1: template(colors[2])
-			image2: template(colors[3])
-			x1: 0, y1: -1.5
-			x2: 0, y2: 0.7
+				image1:						template(						colors[2])
+				image2:						template(						colors[3])
+												x1: 0,		y1: -1.5
+												x2: 0,		y2:  0.7
 		   )}
 		6: { linear_blend(
-			image1: template(colors[2])
-			image2: template(colors[3])
-			x1: 0, y1: -1.5
-			x2: 0, y2: 0.7
+				image1:						template(						colors[2])
+				image2:						template(						colors[3])
+												x1: 0,			y1: -1.5
+												x2: 0,			y2:  0.7
 		   )}
-		7: { template(colors[4]) }
+		7: {								template(						colors[4]) }
 	]
 	horizontal: horizontal_pt_hybrid
 	vertical: [
-		1: { template(colors[0]) }
-		2: { template(colors[1]) }
-		3: { template(colors[2]) }
-		4: { template(colors[3]) }
-		5: { template(colors[4]) }
-		6: { template(colors[5]) }
-		7: { template(colors[6]) }
+		1: {								template(						colors[0])	}
+		2: {								template(						colors[1])	}
+		3: {								template(						colors[2])	}
+		4: {								template(						colors[3])	}
+		5: {								template(						colors[4])	}
+		6: {								template(						colors[5])	}
+		7: {								template(						colors[6])	}
 	]
 	overlay: overlay_hybrid
 ]
@@ -335,106 +357,106 @@ pt_hybrid := [
 
 flip_pt_hybrid := [
 	radial: [
-		0: { template("c")       }
-		1: { template(colors[0]) }
-		2: { template(colors[1]) }
-		3: { template(colors[1]) }
-		4: { template(colors[1]) }
-		5: { linear_blend(
-			image1: template(colors[1])
-			image2: template(colors[2])
-			x1: 0, y1: -1
-			x2: 0, y2: 1.8
-		   )}
+		0: {								template(						"c")		}
+		1: {								template(						colors[0])	}
+		2: {								template(						colors[1])	}
+		3: {								template(						colors[1])	}
+		4: {								template(						colors[1])	}
+		5: {linear_blend(
+				image1:						template(						colors[1])
+				image2:						template(						colors[2])
+												x1: 0,			y1: -1
+												x2: 0,			y2:  1.8
+		)}
 		6: { linear_blend(
-			image1: template(colors[1])
-			image2: template(colors[2])
-			x1: 0, y1: -1
-			x2: 0, y2: 1.8
-		   )}
-		7: { template(colors[4]) }
+				image1:						template(						colors[1])
+				image2:						template(						colors[2])
+												x1: 0,			y1: -1
+												x2: 0,			y2:  1.8
+		)}
+		7: {								template(						colors[4]) }
 	]
 	horizontal: horizontal_pt_hybrid
 	vertical: [
-		1: { template(colors[0]) }
-		2: { template(colors[0]) }
+		1: {								template(						colors[0]) }
+		2: {								template(						colors[0]) }
 		3: { linear_blend(
-			image1: template(colors[0])
-			image2: template(colors[1])
-			x1: 0, y1: 0
-			x2: 0, y2: 2
-		   )}
+				image1:						template(						colors[0])
+				image2:						template(						colors[1])
+												x1: 0,			y1: 0
+												x2: 0,			y2: 2
+		)}
 		4: { linear_blend(
-			image1: template(colors[0])
-			image2: template(colors[1])
-			x1: 0, y1: -1.5
-			x2: 0, y2: 1
+				image1:						template(						colors[0])
+				image2:						template(						colors[1])
+												x1: 0,		y1: -1.5
+												x2: 0,		y2:  1
 		   )}
 		5: { linear_blend(
-			image1: template(colors[0])
-			image2: template(colors[1])
-			x1: 0, y1: -1.1
-			x2: 0, y2: 0.2
-		   )}
-		6: { template(colors[1]) } # Probably not right
-		7: { template(colors[2]) }
+				image1:						template(						colors[0])
+				image2:						template(						colors[1])
+												x1: 0,			y1: -1.1
+												x2: 0,			y2:  0.2
+		)}
+		6: {								template(						colors[1]) } # Probably not right
+		7: {								template(						colors[2]) }
 	]
 	overlay: overlay_hybrid
 ]
 
 flip_pt_hybrid2 := [
 	radial: [
-		0: { template("c")       }
-		1: { template(colors[0]) }
-		2: { template(colors[0]) }
+		0: {								template(						"c")       }
+		1: {								template(						colors[0]) }
+		2: {								template(						colors[0]) }
 		3: { linear_blend(
-			image1: template(colors[0])
-			image2: template(colors[2])
-			x1: 0, y1: -1
-			x2: 0, y2: 1.1
+				image1:						template(						colors[0])
+				image2:						template(						colors[2])
+												x1: 0,			y1: -1
+												x2: 0,			y2:  1.1
 		   )}
-		4: { template(colors[3]) }
-		5: { template(colors[4]) }
-		6: { template(colors[5]) }
-		7: { template(colors[5]) }
+		4: {								template(						colors[3]) }
+		5: {								template(						colors[4]) }
+		6: {								template(						colors[5]) }
+		7: {								template(						colors[5]) }
 	]
 	horizontal: [
-		1: { template(colors[0]) }
-		2: { template(colors[0]) }
-		3: { template(colors[0]) }
+		1: {								template(						colors[0]) }
+		2: {								template(						colors[0]) }
+		3: {								template(						colors[0]) }
 		4: { linear_blend(
-			image1: template(colors[0])
-			image2: template(colors[1])
-			x1: 0.4,  y1: 0
-			x2: 1.5,  y2: 0
+				image1:						template(						colors[0])
+				image2:						template(						colors[1])
+												x1: 0.4,		y1: 0
+												x2: 1.5,		y2: 0
 		   )}
 		5: { linear_blend(
-			image1: template(colors[0])
-			image2: template(colors[1])
-			x1: 0.08,  y1: 0
-			x2: 0.65,  y2: 0
+				image1:						template(						colors[0])
+				image2:						template(						colors[1])
+												x1: 0.08,		y1: 0
+												x2: 0.65,		y2: 0
 		   )}
-		6: { template(colors[5]) } #TODO
-		7: { template(colors[6]) } #TODO
+		6: {								template(						colors[5]) } #TODO
+		7: {								template(						colors[6]) } #TODO
 	]
 	vertical: [
-		1: { template(colors[0]) }
-		2: { template(colors[1]) }
+		1: {								template(						colors[0]) }
+		2: {								template(						colors[1]) }
 		3: { linear_blend(
-			image1: template(colors[1])
-			image2: template(colors[2])
-			x1: 0, y1: -1
-			x2: 0, y2: 1.5
+				image1:						template(						colors[1])
+				image2:						template(						colors[2])
+												x1: 0,			y1: -1
+												x2: 0,			y2:  1.5
 		   )}
 		4: { linear_blend(
-			image1: template(colors[2])
-			image2: template(colors[3])
-			x1: 0, y1: 0.5
-			x2: 0, y2: 3
+				image1:						template(						colors[2])
+				image2:						template(						colors[3])
+												x1: 0,			y1: 0.5
+												x2: 0,			y2: 3
 		   )}
-		5: { template(colors[3]) }
-		6: { template(colors[5]) } # Probably not right
-		7: { template(colors[6]) }
+		5: {								template(						colors[3]) }
+		6: {								template(						colors[5]) } # Probably not right
+		7: {								template(						colors[6]) }
 	]
 	overlay: overlay_hybrid
 ]
@@ -446,117 +468,117 @@ flip_pt_hybrid2 := [
 
 leveler_pt_hybrid := [
 	radial: [
-		0: { template("c")       }
-		1: { template(colors[0]) }
-		2: { template(colors[1]) }
+		0: {								template(						"c")       }
+		1: {								template(						colors[0]) }
+		2: {								template(						colors[1]) }
 		3: { linear_blend(
-			image1: template(colors[1])
-			image2: template(colors[2])
-			x1: 0, y1: 0
-			x2: 0, y2: 1
+				image1:						template(						colors[1])
+				image2:						template(						colors[2])
+												x1: 0,			y1: 0
+												x2: 0,			y2: 1
 		   )}
-		4: { template(colors[2]) }
-		5: { template(colors[2]) }
-		6: { template(colors[2]) }
-		7: { template(colors[4]) }
+		4: {								template(						colors[2]) }
+		5: {								template(						colors[2]) }
+		6: {								template(						colors[2]) }
+		7: {								template(						colors[4]) }
 	]
 	horizontal: horizontal_pt_hybrid
 	vertical: [
-		1: { template(colors[0]) }
-		2: { template(colors[1]) }
+		1: {								template(						colors[0]) }
+		2: {								template(						colors[1]) }
 		3: { linear_blend(
-			image1: template(colors[1])
-			image2: template(colors[2])
-			x1: 0, y1: 0
-			x2: 0, y2: 1
-		   )}
-		4: { template(colors[2]) }
-		5: { template(colors[3]) }
+				image1:						template(						colors[1])
+				image2:						template(						colors[2])
+												x1: 0,			y1: 0
+												x2: 0,			y2: 1
+		)}
+		4: {								template(						colors[2]) }
+		5: {								template(						colors[3]) }
 		6: { linear_blend(
-			image1: template(colors[3])
-			image2: template(colors[4])
-			x1: 0, y1: 0
-			x2: 0, y2: 0.25
-		   )}
-		7: { template(colors[5]) }
+				image1:						template(						colors[3])
+				image2:						template(						colors[4])
+												x1: 0,			y1: 0
+												x2: 0,			y2: 0.25
+		)}
+		7: {								template(						colors[5]) }
 	]
 	overlay: overlay_hybrid
 ]
 
 leveler_pt_hybrid2 := [
 	radial: [
-		0: { template("c")       }
-		1: { template(colors[0]) }
-		2: { template(colors[1]) }
-		3: { template(colors[2]) }
-		4: { template(colors[2]) }
-		5: { template(colors[2]) }
-		6: { template(colors[2]) }
-		7: { template(colors[4]) }
+		0: {								template(						"c")       }
+		1: {								template(						colors[0]) }
+		2: {								template(						colors[1]) }
+		3: {								template(						colors[2]) }
+		4: {								template(						colors[2]) }
+		5: {								template(						colors[2]) }
+		6: {								template(						colors[2]) }
+		7: {								template(						colors[4]) }
 	]
 	horizontal: horizontal_pt_hybrid
 	vertical: [
-		1: { template(colors[0]) }
-		2: { template(colors[1]) }
-		3: { template(colors[2]) }
+		1: {								template(						colors[0]) }
+		2: {								template(						colors[1]) }
+		3: {								template(						colors[2]) }
 		4: { linear_blend(
-			image1: template(colors[2])
-			image2: template(colors[3])
-			x1: 0, y1: 0
-			x2: 0, y2: 1
+				image1:						template(						colors[2])
+				image2:						template(						colors[3])
+												x1: 0,			y1: 0
+												x2: 0,			y2: 1
 		   )}
 		5: { linear_blend(
-			image1: template(colors[3])
-			image2: template(colors[4])
-			x1: 0, y1: 0
-			x2: 0, y2: 0.75
+				image1:						template(						colors[3])
+				image2:						template(						colors[4])
+												x1: 0,			y1: 0
+												x2: 0,			y2: 0.75
 		   )}
-		6: { template(colors[4]) }
-		7: { template(colors[5]) }
+		6: {								template(						colors[4]) }
+		7: {								template(						colors[5]) }
 	]
 	overlay: overlay_hybrid
 ]
 
 leveler_pt_hybrid3 := [
 	radial: [
-		0: { template("c")       }
-		1: { template(colors[0]) }
-		2: { template(colors[1]) }
-		3: { template(colors[2]) }
-		4: { template(colors[2]) }
+		0: {								template(						"c")       }
+		1: {								template(						colors[0]) }
+		2: {								template(						colors[1]) }
+		3: {								template(						colors[2]) }
+		4: {								template(						colors[2]) }
 		5: { linear_blend(
-			image1: template(colors[2])
-			image2: template(colors[3])
-			x1: 0, y1: 0
-			x2: 0, y2: 1
+				image1:						template(						colors[2])
+				image2:						template(						colors[3])
+												x1: 0,			y1: 0
+												x2: 0,			y2: 1
 		   )}
 		6: { linear_blend(
-			image1: template(colors[2])
-			image2: template(colors[3])
-			x1: 0, y1: 0
-			x2: 0, y2: 1
+				image1:						template(						colors[2])
+				image2:						template(						colors[3])
+												x1: 0,			y1: 0
+												x2: 0,			y2: 1
 		   )}
-		7: { template(colors[4]) }
+		7: {								template(						colors[4]) }
 	]
 	horizontal: horizontal_pt_hybrid
 	vertical: [
-		1: { template(colors[0]) }
-		2: { template(colors[1]) }
-		3: { template(colors[2]) }
-		4: { template(colors[3]) }
+		1: {								 template(						colors[0]) }
+		2: {								 template(						colors[1]) }
+		3: {								 template(						colors[2]) }
+		4: {								 template(						colors[3]) }
 		5: { linear_blend(
-			image1: template(colors[3])
-			image2: template(colors[4])
-			x1: 0, y1: 0
-			x2: 0, y2: 0.5
+				image1:						template(						colors[3])
+				image2:						template(						colors[4])
+												x1: 0,			y1: 0
+												x2: 0,			y2: 0.5
 		   )}
 		6: { linear_blend(
-			image1: template(colors[4])
-			image2: template(colors[5])
-			x1: 0, y1: 0
-			x2: 0, y2: 0.5
+				image1:						template(						colors[4])
+				image2:						template(						colors[5])
+												x1: 0,			y1: 0
+												x2: 0,			y2: 0.5
 		   )}
-		7: { template(colors[5]) }
+		7: {								template(						colors[5]) }
 	]
 	overlay: overlay_hybrid
 ]
@@ -567,25 +589,25 @@ leveler_pt_hybrid3 := [
 
 textbox_hybrid := [
 	radial: [
-		0: { template("c")       }
-		1: { template(colors[0]) }
-		2: card_hybrid_2
-		3: { template(colors[2]) }
-		4: { card_hybrid_2(colors: colors[3] + colors[2]) }
-		5: { template(colors[3]) }
-		6: { card_hybrid_2(colors: colors[4] + colors[3]) }
-		7: { template(colors[4]) }
+		0: {								template(						"c")       }
+		1: {								template(						colors[0]) }
+		2:									card_hybrid_2
+		3: {								template(						colors[2]) }
+		4: {								card_hybrid_2(					colors: colors[3] + colors[2]) }
+		5: {								template(colors[3]) }
+		6: {								card_hybrid_2(					colors: colors[4] + colors[3]) }
+		7: {								template(						colors[4]) }
 	]
 	horizontal: horizontal_card_hybrid
 	vertical:  [
-		0: { template("c")       }
-		1: { template(colors[0]) }
-		2: { template(colors[1]) }
-		3: { template(colors[2]) } # TODO
-		4: { template(colors[3]) }
-		5: { template(colors[4]) }
-		6: { template(colors[5]) }
-		7: { template(colors[6]) }
+		0: {								template(						"c")       }
+		1: {								template(						colors[0]) }
+		2: {								template(						colors[1]) }
+		3: {								template(						colors[2]) } # TODO
+		4: {								template(						colors[3]) }
+		5: {								template(						colors[4]) }
+		6: {								template(						colors[5]) }
+		7: {								template(						colors[6]) }
 	]
 	overlay: overlay_hybrid
 ]
@@ -597,45 +619,56 @@ typeline_hybrid := textbox_hybrid
 ########################################################################
 
 identity_horizontal_hybrid := [
-	0: { template("c") }
-	1: { template(colors[0]) }
-	2: { linear_blend(
-		image1: template(colors[0])
-		image2: template(colors[1])
-		x1: 0.49,  y1: 0.49
-		x2: 0.5,  y2: 0.5
+	0: {									template(						"c") }
+	1: {									template(						colors[0]) }
+	2: {linear_blend(
+			image1:							template(						colors[0])
+			image2:							template(						colors[1])
+												x1: 0.49,		y1: 0.49
+												x2: 0.5,		y2: 0.5
 	   )}
-	3: {masked_blend(light: masked_blend(light: template(colors[0]), dark: template(colors[2]), mask: "/magic-identity-new.mse-include/imask_32.png"), dark: template(colors[1]), mask: "/magic-identity-new.mse-include/imask_33.png")}
+	3: {masked_blend(
+		light: masked_blend(
+		light:								template(						colors[0]), 
+		dark:								template(						colors[2]), 
+		mask:									"/magic-identity-new.mse-include/imask_32.png"),
+		dark:								template(						colors[1]), 
+		mask:									"/magic-identity-new.mse-include/imask_33.png")}
 	4: {masked_blend(
 		light: masked_blend(
-			light: masked_blend(light: template(colors[1]), dark: template(colors[0]), mask: "/magic-identity-new.mse-include/imask_42.png"),
-			dark: template(colors[2]),
-			mask: "/magic-identity-new.mse-include/imask_43.png")
-		dark: template(colors[3]),
-		mask: "/magic-identity-new.mse-include/imask_44.png"
+			light: masked_blend(
+				light:						template(						colors[1]), 
+				dark:						template(						colors[0]),
+				mask:							"/magic-identity-new.mse-include/imask_42.png"
+			),
+			dark:							template(						colors[2]),
+			mask:								"/magic-identity-new.mse-include/imask_43.png"
+			)
+		dark:								template(						colors[3]),
+		mask:									"/magic-identity-new.mse-include/imask_44.png"
 		)}
 	5: {masked_blend(
 		light: masked_blend(
 			light: masked_blend(
 				light: masked_blend(
-					light: template(colors[0]),
-					dark: template(colors[4]),
-					mask: "/magic-identity-new.mse-include/imask_52.png"),
-				dark: template(colors[1]),
-				mask: "/magic-identity-new.mse-include/imask_53.png"),
-			dark: template(colors[2]),
-			mask: "/magic-identity-new.mse-include/imask_54.png"),
-		dark: template(colors[3]),
-		mask: "/magic-identity-new.mse-include/imask_55.png")
+					light:					template(						colors[0]),
+					dark:					template(						colors[4]),
+					mask:						"/magic-identity-new.mse-include/imask_52.png"),
+				dark:						template(						colors[1]),
+				mask:							"/magic-identity-new.mse-include/imask_53.png"),
+			dark:							template(						colors[2]),
+			mask:								"/magic-identity-new.mse-include/imask_54.png"),
+		dark:								template(						colors[3]),
+		mask:									"/magic-identity-new.mse-include/imask_55.png")
 		}
-	6: { template("m") }
-]
+	6: {									template(						"m") }
 
+]
 identity_hybrid := [
-	radial: identity_horizontal_hybrid
-	vertical: identity_horizontal_hybrid
-	horizontal: identity_horizontal_hybrid
-	overlay: identity_horizontal_hybrid
+	radial:			identity_horizontal_hybrid
+	vertical:		identity_horizontal_hybrid
+	horizontal:		identity_horizontal_hybrid
+	overlay:		identity_horizontal_hybrid
 ]
 
 ########################################################################
@@ -644,83 +677,83 @@ identity_hybrid := [
 # These are easier
 
 horizontal_stamp_hybrid := [
-	1: { template(colors[0]) }
+	1: {									template(						colors[0]) }
 	2: { linear_blend(
-		image1: template(colors[0])
-		image2: template(colors[1])
-		x1: -0.3,  y1: 0
-		x2: 1.3,  y2: 0
+			image1:							template(						colors[0])
+			image2:							template(						colors[1])
+												x1: -0.3,		y1: 0
+												x2:  1.3,		y2: 0
 	   )}
-	3: { template(colors[1]) }
+	3: {									template(						colors[1]) }
 	4: { linear_blend(
-		image1: template(colors[1])
-		image2: template(colors[2])
-		x1: -0.3,  y1: 0
-		x2: 1.3,  y2: 0
+			image1:							template(						colors[1])
+			image2:							template(						colors[2])
+												x1: -0.3,		y1: 0
+												x2:  1.3,		y2: 0
 	   )}
 	5: {linear_blend(
-		image1: template(colors[1])
-		x1: -0.55,  y1: 0
-		x2: 0.2,   y2: 0
-		image2: linear_blend(
-		  image1: template(colors[2])
-		  x1: 0.8,   y1: 0
-		  x2: 1.55,  y2: 0
-		  image2: template(colors[3])
+			image1:							template(						colors[1])
+												x1: -0.55,		y1: 0
+												x2:  0.2,		y2: 0
+			image2: linear_blend(
+				image1:						template(						colors[2])
+				image2:						template(						colors[3])
+												x1: 0.8,		y1: 0
+												x2: 1.55,		y2: 0
 	   ))}
 	6: { linear_blend(
-		image1: template(colors[2])
-		image2: template(colors[3])
-		x1: 0.1,  y1: 0
-		x2: 0.9,  y2: 0
+			image1:							template(						colors[2])
+			image2:							template(						colors[3])
+												x1: 0.1,		y1: 0
+												x2: 0.9,		y2: 0
 	   )}
 	7: {linear_blend(
-		image1: template(colors[2])
-		x1: -0.55,  y1: 0
-		x2: 0.2,   y2: 0
-		image2: linear_blend(
-		  image1: template(colors[3])
-		  x1: 0.8,   y1: 0
-		  x2: 1.55,  y2: 0
-		  image2: template(colors[4])
+			image1:							template(						colors[2])
+												x1: -0.55,		y1: 0
+												x2:  0.2,		y2: 0
+			image2: linear_blend(
+				image1:						template(						colors[3])
+				image2:						template(						colors[4])
+												x1: 0.8,		y1: 0
+												x2: 1.55,		y2: 0
 	   ))}
 ]
 
 stamp_hybrid := [
 	radial: [
-		0: { template("c")       }
-		1: { template(colors[0]) }
+		0: {								template(						"c")       }
+		1: {								template(						colors[0]) }
 		2: { linear_blend(
-			image1: template(colors[0])
-			image2: template(colors[1])
-			x1: -0.3,  y1: 0
-			x2: 1.3,  y2: 0
+				image1:						template(						colors[0])
+				image2:						template(						colors[1])
+												x1: -0.3,		y1: 0
+												x2:  1.3,		y2: 0
 		   )}
-		3: { template(colors[2]) }
+		3: {								template(						colors[2]) }
 		4: { linear_blend(
-			image1: template(colors[3])
-			image2: template(colors[2])
-			x1: -0.3,  y1: 0
-			x2: 1.3,  y2: 0
+				image1:						template(						colors[3])
+				image2:						template(						colors[2])
+												x1: -0.3,		y1: 0
+												x2:  1.3,		y2: 0
 		   )}
-		5: { template(colors[3]) }
+		5: {								template(						colors[3]) }
 		6: { linear_blend(
-			image1: template(colors[4])
-			image2: template(colors[3])
-			x1: -0.3,  y1: 0
-			x2: 1.3,  y2: 0
+				image1:						template(						colors[4])
+				image2:						template(						colors[3])
+													x1: -0.3,	y1: 0
+													x2:  1.3,	y2: 0
 		   )}
-		7: { template(colors[4]) }
+		7: {								template(						colors[4]) }
 	]
 	horizontal: horizontal_stamp_hybrid
 	vertical: [
-		1: { template(colors[0]) }
-		2: { template(colors[1]) }
-		3: { template(colors[2]) }
-		4: { template(colors[3]) }
-		5: { template(colors[4]) }
-		6: { template(colors[5]) }
-		7: { template(colors[6]) }
+		1: {								template(						colors[0]) }
+		2: {								template(						colors[1]) }
+		3: {								template(						colors[2]) }
+		4: {								template(						colors[3]) }
+		5: {								template(						colors[4]) }
+		6: {								template(						colors[5]) }
+	#	7: {								template(						colors[6]) }
 	]
 	overlay: overlay_hybrid
 ]
@@ -743,19 +776,19 @@ color_background := {
 		input := "white,blue,red,{hybrid_previews},horizontal,reversed"
 	
 	# What type of 'hybrid'?
-	land     := chosen(choice:"land")
-	multi    := chosen(choice:"multicolor")
-	hybrid   := chosen(choice:"hybrid")
-	artifact := chosen(choice:"artifact")
+	land		:= chosen(choice:"land")
+	multi		:= chosen(choice:"multicolor")
+	hybrid		:= chosen(choice:"hybrid")
+	artifact	:= chosen(choice:"artifact")
 	if land and colored_lands then template := land_template # use land template instead?
 	
 	# The selected colors
 	colors := sort_text( order: "(wubrg)"
-	                   , (if chosen(choice:"white") then "w")
-	                   + (if chosen(choice:"blue")  then "u")
-	                   + (if chosen(choice:"black") then "b")
-	                   + (if chosen(choice:"red")   then "r")
-	                   + (if chosen(choice:"green") then "g"))
+						, (if chosen(choice:"white"	)	then "w")
+						+ (if chosen(choice:"blue"	)	then "u")
+						+ (if chosen(choice:"black"	)	then "b")
+						+ (if chosen(choice:"red"	)	then "r")
+						+ (if chosen(choice:"green"	)	then "g"))
 	if multi and (hybrid or colors == "") then (
 		colors := colors + "m"
 		multi := false
@@ -766,13 +799,13 @@ color_background := {
 	)
 	if chosen(choice:"reversed") then colors := reverse(colors)
 	color_count := number_of_items(in: colors)
-	if colors == "" then colors == "c"
+	if colors   == "" then colors == "c"
 	
 	# 'shape' / type of hybrid
-	shape := if      chosen(choice:"horizontal") then "horizontal"
-	         else if chosen(choice:"vertical")   then "vertical"
-	         else if chosen(choice:"overlay")    then "overlay"
-	         else                                     "radial"
+	shape := if			chosen(choice:"horizontal"	)	then	"horizontal"
+	         else if	chosen(choice:"vertical"	)	then	"vertical"
+	         else if	chosen(choice:"overlay"		)	then	"overlay"
+	         else												"radial"
 	
 	# Determine background (allows styles to hook something else here)
 	color_combination()
@@ -785,69 +818,73 @@ color_combination := {
 	# Put a frame around it?
 	if land and not colored_lands then
 		masked_blend(
-			mask:  "multicolor_blend_{type}.png",
-			dark:  land_template("c"),
-			light: base,
+			light:							base,
+			dark:							land_template(					"c"),
+			mask								"multicolor_blend_{type}.png",
+			
 		)
 	else if land and multi and mask_multi_land_with_color() then
 		masked_blend(
-			mask:  "hybrid_blend_{type}.png",
-			dark:  base,
-			light:  land_template("m"),
+			light:							land_template(					"m"),
+			dark:							base,
+			mask:								"hybrid_blend_{type}.png",
 		)
+	#	7: {								template(						colors[6]) }
 	else if multi and artifact then
 		masked_blend(
-			mask: "artifact_blend_{type}.png",
-			dark: template("a"),
-			light: masked_blend(
-				mask: "multicolor_blend_{type}.png",
-				dark: template("m"),
-				light: base
+			light:							masked_blend(
+				light:						base
+				dark:						template(						"m"),
+				mask:							"multicolor_blend_{type}.png",
 			)
+			dark:							template(						"a"),
+			mask:								"artifact_blend_{type}.png",
+			
 		)
 	else if multi then 
 		masked_blend(
-			mask:  "multicolor_blend_{type}.png",
-			dark:  template("m"),
-			light: base,
-		)
+			light:							base,
+			dark:							template("m"),
+			mask:							"multicolor_blend_{type}.png",
+			)
 	else if artifact and color_count > 1 and mask_hybrid_with_land() then 
 		masked_blend(
-			mask:  "artifact_blend_{type}.png",
-			dark:  template("a"),
-			light: masked_blend(
-				mask: "multicolor_blend_{type}.png",
-				dark: template("c"),
-				light: base
+			light:							masked_blend(
+				light:							base
+				dark:							template("c"),
+				mask:							"multicolor_blend_{type}.png",
 			)
+			dark:							template("a"),
+			mask:							"artifact_blend_{type}.png",
+			
 		)
 	else if artifact and color_count > 1 and mask_hybrid_with_gold() then 
 		masked_blend(
-			mask:  "artifact_blend_{type}.png",
-			dark:  template("a"),
-			light: masked_blend(
-				mask: "multicolor_blend_{type}.png",
-				dark: template("m"),
-				light: base
-			)
+			light:							masked_blend(
+				light:							base
+				dark:							template("m"),
+				mask:							"multicolor_blend_{type}.png",
+			)dark:							template("a"),
+			mask:							"artifact_blend_{type}.png",
+			
 		)
 	else if artifact then 
 		masked_blend(
-			mask:  "artifact_blend_{type}.png",
-			dark:  template("a"),
-			light: base,
+			light:							base,
+			dark:							template("a"),
+			mask:							"artifact_blend_{type}.png",
 		)
 	else if color_count > 1 and mask_hybrid_with_land() then
 		masked_blend(
-			mask:  "hybrid_blend_{type}.png",
-			dark:  land_template("c"),
-			light: base,
+			light:							base,
+			dark:							land_template("c"),
+			mask:								"hybrid_blend_{type}.png",
 		)
 	else if color_count > 1 and mask_hybrid_with_gold() then
 		masked_blend(
-			mask:  "hybrid_blend_{type}.png",
-			dark:  land_template("m"),
-			light: base,
+			light:							base,
+			dark:							land_template("m"),
+			mask:								"hybrid_blend_{type}.png",
 		)
 	else base
 }
@@ -856,26 +893,26 @@ color_combination := {
 # Specific types
 ########################################################################
 
-card_background := { color_background(type:"card",     base_hybrid:card_hybrid) }
-card_ptbox      := { color_background(type:"pt",       base_hybrid:pt_hybrid) }
-flip_ptbox      := { color_background(type:"pt",       base_hybrid:flip_pt_hybrid) }
-flip_ptbox2     := { color_background(type:"pt2",      base_hybrid:flip_pt_hybrid2) }
-leveler_ptbox   := { color_background(type:"pt",       base_hybrid:leveler_pt_hybrid) }
-leveler_ptbox2  := { color_background(type:"pt",       base_hybrid:leveler_pt_hybrid2) }
-leveler_ptbox3  := { color_background(type:"pt",       base_hybrid:leveler_pt_hybrid3) }
-card_textbox    := { color_background(type:"textbox",  base_hybrid:textbox_hybrid) }
-card_typeline   := { color_background(type:"typeline", base_hybrid:typeline_hybrid) }
-card_identity   := { color_background(type:"identity", base_hybrid:identity_hybrid) }
-card_identity_2   := { color_background(type:"identity2", base_hybrid:identity_hybrid) }
-card_stamp      := { color_background(type:"stamp",    base_hybrid:stamp_hybrid) }
-card_stamp2     := { color_background(type:"stamp2",   base_hybrid:stamp_hybrid) }
+card_background		:= { color_background(type:"card",			base_hybrid:card_hybrid)			}
+card_ptbox			:= { color_background(type:"pt",			base_hybrid:pt_hybrid)				}
+flip_ptbox			:= { color_background(type:"pt",			base_hybrid:flip_pt_hybrid)			}
+flip_ptbox2			:= { color_background(type:"pt2",			base_hybrid:flip_pt_hybrid2)		}
+leveler_ptbox		:= { color_background(type:"pt",			base_hybrid:leveler_pt_hybrid)		}
+leveler_ptbox2		:= { color_background(type:"pt",			base_hybrid:leveler_pt_hybrid2)		}
+leveler_ptbox3		:= { color_background(type:"pt",			base_hybrid:leveler_pt_hybrid3)		}
+card_textbox		:= { color_background(type:"textbox",		base_hybrid:textbox_hybrid)			}
+card_typeline		:= { color_background(type:"typeline",		base_hybrid:typeline_hybrid)		}
+card_identity		:= { color_background(type:"identity",		base_hybrid:identity_hybrid)		}
+card_identity_2		:= { color_background(type:"identity2",		base_hybrid:identity_hybrid)		}
+card_stamp			:= { color_background(type:"stamp",			base_hybrid:stamp_hybrid)			}
+card_stamp2			:= { color_background(type:"stamp2",		base_hybrid:stamp_hybrid)			}
 
 flip_background := {
 	linear_blend(
-		image1: card_background(top)
-		image2: card_background(bottom)
-		x1: 0,  y1: 0.4
-		x2: 0,  y2: 0.6
+		image1:		card_background(top)
+		image2:		card_background(bottom)
+						x1: 0,		y1: 0.4
+						x2: 0,		y2: 0.6
 	)
 }
 
@@ -887,36 +924,36 @@ flip_background := {
 font_colors_white := { input == "b" or input == "l" }
 
 font_color_positions := [
-	radial:     [0,0,0,2,3,3,4,4]
-	horizontal: [0,0,0,0,0,0,0,0]
-	vertical:   [0,0,1,2,3,4,5,6]
-	overlay:    [0,0,0,0,0,0,0,0]
+	radial:			[0,0,0,2,3,3,4,4]
+	horizontal:		[0,0,0,0,0,0,0,0]
+	vertical:		[0,0,1,2,3,4,5,6]
+	overlay:		[0,0,0,0,0,0,0,0]
 ]
 
 # Determine whether light or dark fonts should be used
-font_white := {
-	hybrid   := chosen(choice:"hybrid")
-	artifact := chosen(choice:"artifact")
-	colors := sort_text( order: "(wubrg)"
-		           , (if chosen(choice:"white") then "w")
-		           + (if chosen(choice:"blue")  then "u")
-		           + (if chosen(choice:"black") then "b")
-		           + (if chosen(choice:"red")   then "r")
-		           + (if chosen(choice:"green") then "g"))
-		           + (if artifact               then "a")
+font_white	:= {
+	hybrid		:=		  chosen(choice:"hybrid"	)
+	artifact	:=		  chosen(choice:"artifact"	)
+	colors		:= sort_text( order: "(wubrg)"
+					, (if chosen(choice:"white"		)	then "w")
+					+ (if chosen(choice:"blue"		)	then "u")
+					+ (if chosen(choice:"black"		)	then "b")
+					+ (if chosen(choice:"red"		)	then "r")
+					+ (if chosen(choice:"green"		)	then "g"))
+					+ (if artifact						then "a")
 	font_colors_white(
-		if chosen(choice:"land") then "l"
-		else if input == "artifact, multicolor" then "a"
-		else if chosen(choice:"multicolor")     then "m"
-		else if artifact and not hybrid         then "a"
-		else if colors == ""                    then "c"
-		else colors[
-			font_color_positions[
-				if      chosen(choice:"horizontal") then "horizontal"
-				else if chosen(choice:"vertical")   then "vertical"
-				else if chosen(choice:"overlay")    then "overlay"
-				else                                     "radial"
-			][number_of_items(in: colors)]
+		if			chosen(choice:"land") then "l"
+		else if		input == "artifact, multicolor"		then "a"
+		else if		chosen(choice:"multicolor")			then "m"
+		else if		artifact and not hybrid				then "a"
+		else if		colors == ""						then "c"
+		else		colors[
+						font_color_positions[
+							if			chosen(choice:"horizontal") then	"horizontal"
+							else if		chosen(choice:"vertical")   then	"vertical"
+							else if		chosen(choice:"overlay")    then	"overlay"
+							else											"radial"
+						][number_of_items(in: colors)]
 		]
 	)
 }

--- a/magic-blends.mse-include/new-blends
+++ b/magic-blends.mse-include/new-blends
@@ -85,18 +85,17 @@ vertical_card_hybrid	:= {
 	card_hybrid.horizontal[color_count]()
 }
 
-
 horizontal_card_hybrid := [
 	1:	{ 									template(						colors[0])}
 	2:										card_hybrid_2
 
 	3: {linear_blend(
-			image1:							template(						colors[0])	,
+			image1:							template(						colors[("{offset}" + 0) mod 3])	,
 												x1: 0.22,		y1: 0
 												x2: 0.4,		y2: 0
 			image2: linear_blend(
-				image1:						template(						colors[1])	,
-				image2: 					template(						colors[2])	,
+				image1:						template(						colors[("{offset}" + 1) mod 3])	,
+				image2: 					template(						colors[("{offset}" + 2) mod 3])	,
 												x1: 0.6,		y1: 0
 												x2: 0.78,		y2: 0
 			)
@@ -104,85 +103,85 @@ horizontal_card_hybrid := [
 	}
 
 	4: {linear_blend(
-			image1:							template(						colors[0])	,
+			image1:							template(						colors[("{offset}" + 0) mod 4])	,
 												x1: 0.15,		y1: 0
 												x2: 0.31,		y2: 0
 			image2: linear_blend(
-				image1:						template(						colors[1])	,
+				image1:						template(						colors[("{offset}" + 1) mod 4])	,
 												x1: 0.42,		y1: 0
 												x2: 0.58,		y2: 0
 				image2: linear_blend(
-					image1:					template(						colors[2])	,
-					image2:					template(						colors[3])	,
+					image1:					template(						colors[("{offset}" + 2) mod 4])	,
+					image2:					template(						colors[("{offset}" + 3) mod 4])	,
 												x1: 0.69,		y1: 0
 												x2: 0.85,		y2: 0
 	)))}
 
 	5: {linear_blend(
-			image1: 						template(						colors[0])	,
+			image1: 						template(						colors[("{offset}" + 0) mod 5])	,
 												x1:  2.0 / 15,	y1: 0
 												x2:  4.0 / 15,	y2: 0
 			image2: linear_blend(
-				image1: 					template(						colors[1])	,
+				image1: 					template(						colors[("{offset}" + 1) mod 5])	,
 												x1:  5.0 / 15,	y1: 0
 												x2:  7.0 / 15,	y2: 0
 				image2: linear_blend(
-					image1: 				template(						colors[2])	,
+					image1: 				template(						colors[("{offset}" + 2) mod 5])	,
 												x1:  8.0 / 15,	y1: 0
 												x2: 10.0 / 15,	y2: 0
 					image2: linear_blend(
-						image1:				template(						colors[3])	,
-						image2:				template(						colors[4])	,
+						image1:				template(						colors[("{offset}" + 3) mod 5])	,
+						image2:				template(						colors[("{offset}" + 4) mod 5])	,
 												x1: 11.0 / 15,	y1: 0
 												x2: 13.0 / 15,	y2: 0
 	))))}
 
 	6: {linear_blend(
-			image1:							template(						colors[0])	,
+			image1:							template(						colors[("{offset}" + 0) mod 6])	,
 												x1:  1.5 / 15,	y1: 0
 												x2:  3.1 / 15,	y2: 0
 			image2: linear_blend(
-				image1:						template(						colors[1])	,
+				image1:						template(						colors[("{offset}" + 1) mod 6])	,
 												x1:  4.1 / 15,	y1: 0
 												x2:  5.7 / 15,	y2: 0
 				image2: linear_blend(
-					image1:					template(						colors[2])	,
+					image1:					template(						colors[("{offset}" + 2) mod 6])	,
 												x1:  6.7 / 15,	y1: 0
 												x2:  8.3 / 15,	y2: 0
 					image2: linear_blend(
-						image1:				template(						colors[3])	,
+						image1:				template(						colors[("{offset}" + 3) mod 6])	,
 												x1:  9.3 / 15,	y1: 0
 												x2: 10.9 / 15,	y2: 0
 						image2: linear_blend(
-							image1:			template(						colors[4])	,
-							image2:			template(						colors[5])	,
+							image1:			template(						colors[("{offset}" + 4) mod 6])	,
+							image2:			template(						colors[("{offset}" + 5) mod 6])	,
 												x1: 11.9 / 15,	y1: 0
 												x2: 13.5 / 15,	y2: 0
 	)))))}
 
 	7: {linear_blend(
-			image1:							template(						colors[0])	,
+			image1:							template(						colors[("{offset}" + 0) mod 7])	,
 												x1:  1.3 / 15,	y1: 0
 												x2:  2.7 / 15,	y2: 0
 			image2: linear_blend(
-				image1:						template(						colors[1])	,
+				image1:						template(						colors[("{offset}" + 1) mod 7])	,
 												x1:  3.5 / 15,	y1: 0
 												x2:  4.9 / 15,	y2: 0
 				image2: linear_blend(
-					image1:					template(						colors[2])	,
+					image1:					template(						colors[("{offset}" + 2) mod 7])	,
 												x1:  5.7 / 15,	y1: 0
 												x2:  7.1 / 15,	y2: 0
 					image2: linear_blend(
-						image1:				template(						colors[3])	,
+						image1:				template(						colors[("{offset}" + 3) mod 7])	,
 												x1:  7.9 / 15,	y1: 0
 												x2:  9.3 / 15,	y2: 0
 						image2: linear_blend(
-							image1:			template(						colors[4])	,
+							image1:			template(						colors[("{offset}" + 4) mod 7])	,
 												x1: 10.1 / 15,	y1: 0
 												x2: 11.5 / 15,	y2: 0
 							image2: linear_blend(
-								image1:		template(						colors[5])	,
-								image2:		template(						colors[6])	,
+								image1:		template(						colors[("{offset}" + 5) mod 7])	,
+								image2:		template(						colors[("{offset}" + 6) mod 7])	,
 												x1: 12.3 / 15,	y1: 0
 												x2: 13.7 / 15,	y2: 0
 		))))))}
@@ -198,39 +197,39 @@ card_hybrid := [
 		2:	card_hybrid_2
 
 		3:{linear_blend(
-			image1: 						card_hybrid_2(					colors: colors[0] + colors[1]	)	,
-			image2: 						template(						colors[2]						)	,
+			image1: 						card_hybrid_2(					colors: colors[("{offset}" + 0) mod 3] + colors[("{offset}" + 1) mod 3]	)	,
+			image2: 						template(						colors[("{offset}" + 2) mod 3]						)	,
 												x1: 0,			y1: 0.55
 												x2: 0,			y2: 0.77
 		)}
 
 		4:{linear_blend(
-			image1:							card_hybrid_2(					colors: colors[0] + colors[1]	)	,
-			image2: 						card_hybrid_2(					colors: colors[3] + colors[2]	)	,
+			image1:							card_hybrid_2(					colors: colors[("{offset}" + 0) mod 4]  + colors[("{offset}" + 1) mod 4] 	)	,
+			image2: 						card_hybrid_2(					colors: colors[("{offset}" + 3) mod 4]  + colors[("{offset}" + 2) mod 4] 	)	,
 												x1: 0,			y1: 0.4
 												x2: 0,			y2: 0.62
 		)}
 
 		5: {linear_blend(
 				image1: linear_blend(
-					image1:					card_hybrid_2(					colors: colors[0] + colors[1]	)	,
-					image2:					card_hybrid_2(					colors: colors[4] + colors[2]	)	,
+					image1:					card_hybrid_2(					colors: colors[(offset + 0) mod 5]  + colors[("{offset}" + 1) mod 5] 	)	,
+					image2:					card_hybrid_2(					colors: colors[(offset + 4) mod 5]  + colors[("{offset}" + 2) mod 5] 	)	,
 												x1: 0,			y1: 0.19
 												x2: 0,			y2: 0.35
 				),
-				image2:						template(						colors[3]						)	,
+				image2:						template(						colors[("{offset}" + 3) mod 5] 						)	,
 												x1: 0,			y1: 0.777
 												x2: 0,			y2: 0.937
 		)}
 
 		6: {linear_blend(
 				image1: linear_blend(
-					image1:					card_hybrid_2(					colors: colors[0] + colors[1]	)	,
-					image2:					card_hybrid_2(					colors: colors[5] + colors[2]	)	,
+					image1:					card_hybrid_2(					colors: colors[("{offset}" + 0) mod 6]  + colors[("{offset}" + 1) mod 6] 	)	,
+					image2:					card_hybrid_2(					colors: colors[("{offset}" + 5) mod 6]  + colors[("{offset}" + 2) mod 6] 	)	,
 												x1: 0,			y1: 0.19
 												x2: 0,			y2: 0.35
 				),
-				image2:						card_hybrid_2(					colors: colors[4] + colors[3]	)	,
+				image2:						card_hybrid_2(					colors: colors[("{offset}" + 4) mod 6]  + colors[("{offset}" + 3) mod 6] 	)	,
 												x1: 0,			y1: 0.777
 												x2: 0,			y2: 0.937
 		)}
@@ -238,16 +237,16 @@ card_hybrid := [
 		7: {linear_blend(
 				image1: linear_blend(
 					image1: linear_blend(
-						image1:				card_hybrid_2(					colors: colors[0] + colors[1]	)	,
-						image2:				card_hybrid_2(					colors: colors[6] + colors[3]	)	,
+						image1:				card_hybrid_2(					colors: colors[("{offset}" + 0) mod 7]  + colors[("{offset}" + 1) mod 7] 	)	,
+						image2:				card_hybrid_2(					colors: colors[("{offset}" + 6) mod 7]  + colors[("{offset}" + 2) mod 7] 	)	,
 												x1: 0,			y1: 0.34
 												x2: 0,			y2: 0.50
 					),
-					image2:					card_hybrid_2(					colors: colors[5] + colors[3]	)	,
+					image2:					card_hybrid_2(					colors: colors[("{offset}" + 5) mod 7]  + colors[("{offset}" + 3) mod 7] 	)	,
 												x1: 0,			y1: 0.877
 												x2: 0,			y2: 0.937
 				),
-				image2:						template(						colors[4]						)	,
+				image2:						template(						colors[("{offset}" + 4) mod 7] 						)	,
 												x1: 0,			y1: 1.140
 												x2: 0,			y2: 1.300
 		   )}
@@ -281,37 +280,37 @@ horizontal_pt_hybrid := [
 	1: {									template(						colors[0]) }
 	2: {									template(						colors[1]) }
 	3: { linear_blend(
-			image1:							template(						colors[1])	,
-			image2:							template(						colors[2])	,
+			image1:							template(						colors[("{offset}" + 1) mod 3] )	,
+			image2:							template(						colors[("{offset}" + 2) mod 3] )	,
 												x1: -0.51,		y1: 0
 												x2:  0.26,		y2: 0
 	)}
 	4: { linear_blend(
-			image1:							template(						colors[2])	,
-			image2:							template(						colors[3])	,
+			image1:							template(						colors[("{offset}" + 2) mod 4] )	,
+			image2:							template(						colors[("{offset}" + 3) mod 4] )	,
 												x1: -0.1,		y1: 0
 												x2:  0.6,		y2: 0
 	)}
 	5: { linear_blend(
-			image1:							template(						colors[3])	,
-			image2:							template(						colors[4])	,
+			image1:							template(						colors[("{offset}" + 3) mod 5] )	,
+			image2:							template(						colors[("{offset}" + 4) mod 5] )	,
 												x1: 0.08,		y1: 0
 												x2: 0.65,		y2: 0
 	)}
 	6: { linear_blend(
-			image1:							template(						colors[4])	,
-			image2:							template(						colors[5])	,
+			image1:							template(						colors[("{offset}" + 4) mod 6] )	,
+			image2:							template(						colors[("{offset}" + 5) mod 6] )	,
 												x1: 0.07,		y1: 0
 												x2: 0.7,		y2: 0
 	)}
 	7: {linear_blend(
 			image1: linear_blend(
-				image1:						template(						colors[4])	,
-				image2:						template(						colors[5])	,
+				image1:						template(						colors[("{offset}" + 4) mod 7] )	,
+				image2:						template(						colors[("{offset}" + 5) mod 7] )	,
 												x1: -0.2,		y1: 0
 												x2:  0.2,		y2: 0
 			),
-			image2:							template(						colors[6]),
+			image2:							template(						colors[("{offset}" + 6) mod 7] ),
 												x1: 0.5,		y1: 0
 												x2: 0.7,		y2: 0
 	)}
@@ -323,31 +322,31 @@ pt_hybrid := [
 		0: {								template(						"c")		}
 		1: {								template(						colors[0])	}
 		2: {								template(						colors[1])	}
-		3: {								template(						colors[2])	}
-		4: {								template(						colors[2])	}
+		3: {								template(						colors[colors[("{offset}" + 2) mod 3] ])	}
+		4: {								template(						colors[colors[("{offset}" + 2) mod 4] ])	}
 		5: { linear_blend(
-				image1:						template(						colors[2])	,
-				image2:						template(						colors[3])	,
+				image1:						template(						colors[colors[("{offset}" + 2) mod 5] ])	,
+				image2:						template(						colors[colors[("{offset}" + 3) mod 5] ])	,
 												x1: 0,		y1: -1.5
 												x2: 0,		y2:  0.7
 		)}
 		6: { linear_blend(
-				image1:						template(						colors[2])	,
-				image2:						template(						colors[3])	,
+				image1:						template(						colors[("{offset}" + 2) mod 6] )	,
+				image2:						template(						colors[("{offset}" + 3) mod 6] )	,
 												x1: 0,			y1: -1.5
 												x2: 0,			y2:  0.7
 		)}
-		7: {								template(						colors[4]) }
+		7: {								template(						colors[("{offset}" + 4) mod 7] ) }
 	]
 	horizontal: horizontal_pt_hybrid
 	vertical: [
 		1: {								template(						colors[0])	}
 		2: {								template(						colors[1])	}
-		3: {								template(						colors[2])	}
-		4: {								template(						colors[3])	}
-		5: {								template(						colors[4])	}
-		6: {								template(						colors[5])	}
-		7: {								template(						colors[6])	}
+		3: {								template(						colors[("{offset}" + 2) mod 7] )	}
+		4: {								template(						colors[("{offset}" + 3) mod 7] )	}
+		5: {								template(						colors[("{offset}" + 4) mod 7] )	}
+		6: {								template(						colors[("{offset}" + 5) mod 7] )	}
+		7: {								template(						colors[("{offset}" + 6) mod 7] )	}
 	]
 	overlay: overlay_hybrid
 ]
@@ -362,46 +361,46 @@ flip_pt_hybrid := [
 		0: {								template(						"c")		}
 		1: {								template(						colors[0])	}
 		2: {								template(						colors[1])	}
-		3: {								template(						colors[1])	}
-		4: {								template(						colors[1])	}
+		3: {								template(						colors[("{offset}" + 1) mod 3] )	}
+		4: {								template(						colors[("{offset}" + 1) mod 4] )	}
 		5: {linear_blend(
-				image1:						template(						colors[1])	,
-				image2:						template(						colors[2])	,
+				image1:						template(						colors[("{offset}" + 1) mod 5] )	,
+				image2:						template(						colors[("{offset}" + 2) mod 5] )	,
 												x1: 0,			y1: -1
 												x2: 0,			y2:  1.8
 		)}
 		6: { linear_blend(
-				image1:						template(						colors[1])	,
-				image2:						template(						colors[2])	,
+				image1:						template(						colors[("{offset}" + 1) mod 6] )	,
+				image2:						template(						colors[("{offset}" + 2) mod 6] )	,
 												x1: 0,			y1: -1
 												x2: 0,			y2:  1.8
 		)}
-		7: {								template(						colors[4]) }
+		7: {								template(						colors[("{offset}" + 4) mod 7] ) }
 	]
 	horizontal: horizontal_pt_hybrid
 	vertical: [
 		1: {								template(						colors[0]) }
 		2: {								template(						colors[0]) }
 		3: { linear_blend(
-				image1:						template(						colors[0])	,
-				image2:						template(						colors[1])	,
+				image1:						template(						colors[("{offset}" + 0) mod 3] )	,
+				image2:						template(						colors[("{offset}" + 1) mod 3] )	,
 												x1: 0,			y1: 0
 												x2: 0,			y2: 2
 		)}
 		4: { linear_blend(
-				image1:						template(						colors[0])	,
-				image2:						template(						colors[1])	,
+				image1:						template(						colors[("{offset}" + 0) mod 4] )	,
+				image2:						template(						colors[("{offset}" + 1) mod 4] )	,
 												x1: 0,		y1: -1.5
 												x2: 0,		y2:  1
 		)}
 		5: { linear_blend(
-				image1:						template(						colors[0])	,
-				image2:						template(						colors[1])	,
+				image1:						template(						colors[("{offset}" + 0) mod 5] )	,
+				image2:						template(						colors[("{offset}" + 1) mod 5] )	,
 												x1: 0,			y1: -1.1
 												x2: 0,			y2:  0.2
 		)}
-		6: {								template(						colors[1]) } # Probably not right
-		7: {								template(						colors[2]) }
+		6: {								template(						colors[("{offset}" + 1) mod 6] ) } # Probably not right
+		7: {								template(						colors[("{offset}" + 2) mod 7] ) }
 	]
 	overlay: overlay_hybrid
 ]
@@ -412,53 +411,53 @@ flip_pt_hybrid2 := [
 		1: {								template(						colors[0]) }
 		2: {								template(						colors[0]) }
 		3: { linear_blend(
-				image1:						template(						colors[0])	,
-				image2:						template(						colors[2])	,
+				image1:						template(						colors[("{offset}" + 0) mod 3] )	,
+				image2:						template(						colors[("{offset}" + 2) mod 3] )	,
 												x1: 0,			y1: -1
 												x2: 0,			y2:  1.1
 		)}
-		4: {								template(						colors[3]) }
-		5: {								template(						colors[4]) }
-		6: {								template(						colors[5]) }
-		7: {								template(						colors[5]) }
+		4: {								template(						colors[("{offset}" + 3) mod 4] ) }
+		5: {								template(						colors[("{offset}" + 4) mod 5] ) }
+		6: {								template(						colors[("{offset}" + 5) mod 6] ) }
+		7: {								template(						colors[("{offset}" + 6) mod 7] ) }
 	]
 	horizontal: [
 		1: {								template(						colors[0]) }
 		2: {								template(						colors[0]) }
-		3: {								template(						colors[0]) }
+		3: {								template(						colors[("{offset}" + 0) mod 3] ) }
 		4: { linear_blend(
-				image1:						template(						colors[0])	,
-				image2:						template(						colors[1])	,
+				image1:						template(						colors[("{offset}" + 0) mod 4] )	,
+				image2:						template(						colors[("{offset}" + 1) mod 4] )	,
 												x1: 0.4,		y1: 0
 												x2: 1.5,		y2: 0
 		)}
 		5: { linear_blend(
-				image1:						template(						colors[0])	,
-				image2:						template(						colors[1])	,
+				image1:						template(						colors[("{offset}" + 0) mod 5] )	,
+				image2:						template(						colors[("{offset}" + 1) mod 5] )	,
 												x1: 0.08,		y1: 0
 												x2: 0.65,		y2: 0
 		)}
-		6: {								template(						colors[5]) } #TODO
-		7: {								template(						colors[6]) } #TODO
+		6: {								template(						colors[("{offset}" + 5) mod 6] ) } #TODO
+		7: {								template(						colors[("{offset}" + 6) mod 7] ) } #TODO
 	]
 	vertical: [
 		1: {								template(						colors[0]) }
 		2: {								template(						colors[1]) }
 		3: { linear_blend(
-				image1:						template(						colors[1])	,
-				image2:						template(						colors[2])	,
+				image1:						template(						colors[("{offset}" + 1) mod 3] )	,
+				image2:						template(						colors[("{offset}" + 2) mod 3] )	,
 												x1: 0,			y1: -1
 												x2: 0,			y2:  1.5
 		)}
 		4: { linear_blend(
-				image1:						template(						colors[2])	,
-				image2:						template(						colors[3])	,
+				image1:						template(						colors[("{offset}" + 2) mod 4] )	,
+				image2:						template(						colors[("{offset}" + 3) mod 4] )	,
 												x1: 0,			y1: 0.5
 												x2: 0,			y2: 3
 		)}
-		5: {								template(						colors[3]) }
-		6: {								template(						colors[5]) } # Probably not right
-		7: {								template(						colors[6]) }
+		5: {								template(						colors[("{offset}" + 3) mod 5] ) }
+		6: {								template(						colors[("{offset}" + 5) mod 6] ) } # Probably not right
+		7: {								template(						colors[("{offset}" + 6) mod 7] ) }
 	]
 	overlay: overlay_hybrid
 ]
@@ -472,35 +471,35 @@ leveler_pt_hybrid := [
 		1: {								template(						colors[0]) }
 		2: {								template(						colors[1]) }
 		3: { linear_blend(
-				image1:						template(						colors[1])	,
-				image2:						template(						colors[2])	,
+				image1:						template(						colors["{offset}" + 1 mod 3] )	,
+				image2:						template(						colors["{offset}" + 2 mod 3] )	,
 												x1: 0,			y1: 0
 												x2: 0,			y2: 1
 		)}
-		4: {								template(						colors[2]) }
-		5: {								template(						colors[2]) }
-		6: {								template(						colors[2]) }
-		7: {								template(						colors[4]) }
+		4: {								template(						colors["{offset}" + 2 mod 4] ) }
+		5: {								template(						colors["{offset}" + 2 mod 5] ) }
+		6: {								template(						colors["{offset}" + 2 mod 6] ) }
+		7: {								template(						colors["{offset}" + 4 mod 7] ) }
 	]
 	horizontal: horizontal_pt_hybrid
 	vertical: [
 		1: {								template(						colors[0]) }
 		2: {								template(						colors[1]) }
 		3: { linear_blend(
-				image1:						template(						colors[1])	,
-				image2:						template(						colors[2])	,
+				image1:						template(						colors["{offset}" + 1 mod 3] )	,
+				image2:						template(						colors["{offset}" + 2 mod 3] )	,
 												x1: 0,			y1: 0
 												x2: 0,			y2: 1
 		)}
-		4: {								template(						colors[2]) }
-		5: {								template(						colors[3]) }
+		4: {								template(						colors["{offset}" + 2 mod 4] ) }
+		5: {								template(						colors["{offset}" + 3 mod 5] ) }
 		6: { linear_blend(
-				image1:						template(						colors[3])	,
-				image2:						template(						colors[4])	,
+				image1:						template(						colors["{offset}" + 2 mod 6] )	,
+				image2:						template(						colors["{offset}" + 4 mod 6] )	,
 												x1: 0,			y1: 0
 												x2: 0,			y2: 0.25
 		)}
-		7: {								template(						colors[5]) }
+		7: {								template(						colors["{offset}" + 5 mod 7] ) }
 	]
 	overlay: overlay_hybrid
 ]
@@ -515,35 +514,35 @@ leveler_pt_hybrid := [
 		1: {								template(						colors[0]) }
 		2: {								template(						colors[1]) }
 		3: { linear_blend(
-				image1:						template(						colors[1])	,
-				image2:						template(						colors[2])	,
+				image1:						template(						colors["{offset}" + 1 mod 3] )	,
+				image2:						template(						colors["{offset}" + 2 mod 3] )	,
 												x1: 0,			y1: 0
 												x2: 0,			y2: 1
 		)}
-		4: {								template(						colors[2]) }
-		5: {								template(						colors[2]) }
-		6: {								template(						colors[2]) }
-		7: {								template(						colors[4]) }
+		4: {								template(						colors["{offset}" + 2 mod 4] ) }
+		5: {								template(						colors["{offset}" + 2 mod 5] ) }
+		6: {								template(						colors["{offset}" + 2 mod 6] ) }
+		7: {								template(						colors["{offset}" + 4 mod 7] ) }
 	]
 	horizontal: horizontal_pt_hybrid
 	vertical: [
 		1: {								template(						colors[0]) }
 		2: {								template(						colors[1]) }
 		3: { linear_blend(
-				image1:						template(						colors[1])	,
-				image2:						template(						colors[2])	,
+				image1:						template(						colors["{offset}" + 1 mod 3] )	,
+				image2:						template(						colors["{offset}" + 2 mod 3] )	,
 												x1: 0,			y1: 0
 												x2: 0,			y2: 1
 		)}
-		4: {								template(						colors[2]) }
-		5: {								template(						colors[3]) }
+		4: {								template(						colors["{offset}" + 2 mod 4] ) }
+		5: {								template(						colors["{offset}" + 3 mod 5] ) }
 		6: { linear_blend(
-				image1:						template(						colors[3])	,
-				image2:						template(						colors[4])	,
+				image1:						template(						colors["{offset}" + 3 mod 6] )	,
+				image2:						template(						colors["{offset}" + 4 mod 6] )	,
 												x1: 0,			y1: 0
 												x2: 0,			y2: 0.25
 		)}
-		7: {								template(						colors[5]) }
+		7: {								template(						colors["{offset}" + 5 mod 7] ) }
 	]
 	overlay: overlay_hybrid
 ]
@@ -553,31 +552,31 @@ leveler_pt_hybrid2 := [
 		0: {								template(						"c")       }
 		1: {								template(						colors[0]) }
 		2: {								template(						colors[1]) }
-		3: {								template(						colors[2]) }
-		4: {								template(						colors[2]) }
-		5: {								template(						colors[2]) }
-		6: {								template(						colors[2]) }
-		7: {								template(						colors[4]) }
+		3: {								template(						colors["{offset}" + 2 mod 3] ) }
+		4: {								template(						colors["{offset}" + 2 mod 4] ) }
+		5: {								template(						colors["{offset}" + 2 mod 5] ) }
+		6: {								template(						colors["{offset}" + 2 mod 6] ) }
+		7: {								template(						colors["{offset}" + 4 mod 7] ) }
 	]
 	horizontal: horizontal_pt_hybrid
 	vertical: [
 		1: {								template(						colors[0]) }
 		2: {								template(						colors[1]) }
-		3: {								template(						colors[2]) }
+		3: {								template(						colors["{offset}" + 2 mod 3] ) }
 		4: { linear_blend(
-				image1:						template(						colors[2])
-				image2:						template(						colors[3])
+				image1:						template(						colors["{offset}" + 2 mod 4] )
+				image2:						template(						colors["{offset}" + 3 mod 4] )
 												x1: 0,			y1: 0
 												x2: 0,			y2: 1
 		   )}
 		5: { linear_blend(
-				image1:						template(						colors[3])
-				image2:						template(						colors[4])
+				image1:						template(						colors["{offset}" + 3 mod 5] )
+				image2:						template(						colors["{offset}" + 4 mod 5] )
 												x1: 0,			y1: 0
 												x2: 0,			y2: 0.75
 		   )}
-		6: {								template(						colors[4]) }
-		7: {								template(						colors[5]) }
+		6: {								template(						colors["{offset}" + 4 mod 6] ) }
+		7: {								template(						colors["{offset}" + 5 mod 7] ) }
 	]
 	overlay: overlay_hybrid
 ]
@@ -587,41 +586,41 @@ leveler_pt_hybrid3 := [
 		0: {								template(						"c")       }
 		1: {								template(						colors[0]) }
 		2: {								template(						colors[1]) }
-		3: {								template(						colors[2]) }
-		4: {								template(						colors[2]) }
+		3: {								template(						colors["{offset}" + 2 mod 3] ) }
+		4: {								template(						colors["{offset}" + 2 mod 4] ) }
 		5: { linear_blend(
-				image1:						template(						colors[2])	,
-				image2:						template(						colors[3]	,)
+				image1:						template(						colors["{offset}" + 2 mod 5] )	,
+				image2:						template(						colors["{offset}" + 3 mod 5] 	,)
 												x1: 0,			y1: 0
 												x2: 0,			y2: 1
 		   )}
 		6: { linear_blend(
-				image1:						template(						colors[2])	,
-				image2:						template(						colors[3])	,
+				image1:						template(						colors["{offset}" + 2 mod 6] )	,
+				image2:						template(						colors["{offset}" + 3 mod 6] )	,
 												x1: 0,			y1: 0
 												x2: 0,			y2: 1
 		   )}
-		7: {								template(						colors[4]) }
+		7: {								template(						colors["{offset}" + 4 mod 7] ) }
 	]
 	horizontal: horizontal_pt_hybrid
 	vertical: [
 		1: {								 template(						colors[0]) }
 		2: {								 template(						colors[1]) }
-		3: {								 template(						colors[2]) }
-		4: {								 template(						colors[3]) }
+		3: {								 template(						colors["{offset}" + 2 mod 3] ) }
+		4: {								 template(						colors["{offset}" + 3 mod 4] ) }
 		5: { linear_blend(
-				image1:						template(						colors[3])	,
-				image2:						template(						colors[4])	,
+				image1:						template(						colors["{offset}" + 3 mod 5] )	,
+				image2:						template(						colors["{offset}" + 4 mod 5] )	,
 												x1: 0,			y1: 0
 												x2: 0,			y2: 0.5
 		   )}
 		6: { linear_blend(
-				image1:						template(						colors[4])	,
-				image2:						template(						colors[5])	,
+				image1:						template(						colors["{offset}" + 4 mod 6] )	,
+				image2:						template(						colors["{offset}" + 5 mod 6] )	,
 												x1: 0,			y1: 0
 												x2: 0,			y2: 0.5
 		   )}
-		7: {								template(						colors[5]) }
+		7: {								template(						colors["{offset}" + 5 mod 7] ) }
 	]
 	overlay: overlay_hybrid
 ]
@@ -636,22 +635,22 @@ textbox_hybrid := [
 		0: {								template(						"c")       }
 		1: {								template(						colors[0]) }
 		2:									card_hybrid_2
-		3: {								template(						colors[2]) }
-		4: {								card_hybrid_2(					colors: colors[3] + colors[2]) }
-		5: {								template(colors[3]) }
-		6: {								card_hybrid_2(					colors: colors[4] + colors[3]) }
-		7: {								template(						colors[4]) }
+		3: {								template(						colors["{offset}" + 2 mod 3] ) }
+		4: {								card_hybrid_2(					colors: colors["{offset}" + 0 mod 4]  + colors["{offset}" + 0 mod 4] ) }
+		5: {								template(						colors["{offset}" + 3 mod 5] ) }
+		6: {								card_hybrid_2(					colors: colors["{offset}" + 0 mod 6]  + colors["{offset}" + 0 mod 6] ) }
+		7: {								template(						colors["{offset}" + 4 mod 7] ) }
 	]
 	horizontal: horizontal_card_hybrid
 	vertical:  [
 		0: {								template(						"c")       }
 		1: {								template(						colors[0]) }
 		2: {								template(						colors[1]) }
-		3: {								template(						colors[2]) } # TODO
-		4: {								template(						colors[3]) }
-		5: {								template(						colors[4]) }
-		6: {								template(						colors[5]) }
-		7: {								template(						colors[6]) }
+		3: {								template(						colors["{offset}" + 2 mod 3] ) } # TODO
+		4: {								template(						colors["{offset}" + 3 mod 4] ) }
+		5: {								template(						colors["{offset}" + 4 mod 5] ) }
+		6: {								template(						colors["{offset}" + 5 mod 6] ) }
+		7: {								template(						colors["{offset}" + 6 mod 7] ) }
 	]
 	overlay: overlay_hybrid
 ]
@@ -726,36 +725,36 @@ horizontal_stamp_hybrid := [
 												x1: -0.3,		y1: 0
 												x2:  1.3,		y2: 0
 	)}
-	3: {									template(						colors[1]) }
+	3: {									template(						colors["{offset}" + 1 mod 3] ) }
 	4: { linear_blend(
-			image1:							template(						colors[1])	,
-			image2:							template(						colors[2])	,
+			image1:							template(						colors["{offset}" + 1 mod 4] )	,
+			image2:							template(						colors["{offset}" + 2 mod 4] )	,
 												x1: -0.3,		y1: 0
 												x2:  1.3,		y2: 0
 	)}
 	5: {linear_blend(
-			image1:							template(						colors[1])
+			image1:							template(						colors["{offset}" + 1 mod 5] )
 												x1: -0.55,		y1: 0
 												x2:  0.2,		y2: 0
 			image2: linear_blend(
-				image1:						template(						colors[2])	,
-				image2:						template(						colors[3])	,
+				image1:						template(						colors["{offset}" + 2 mod 5] )	,
+				image2:						template(						colors["{offset}" + 3 mod 5] )	,
 												x1: 0.8,		y1: 0
 												x2: 1.55,		y2: 0
 	))}
 	6: { linear_blend(
-			image1:							template(						colors[2])	,
-			image2:							template(						colors[3])	,
+			image1:							template(						colors["{offset}" + 2 mod 6] )	,
+			image2:							template(						colors["{offset}" + 3 mod 6] )	,
 												x1: 0.1,		y1: 0
 												x2: 0.9,		y2: 0
 	)}
 	7: {linear_blend(
-			image1:							template(						colors[2])	,
+			image1:							template(						colors["{offset}" + 2 mod 7] )	,
 												x1: -0.55,		y1: 0
 												x2:  0.2,		y2: 0
 			image2: linear_blend(
-				image1:						template(						colors[3])	,
-				image2:						template(						colors[4])	,
+				image1:						template(						colors["{offset}" + 3 mod 7] )	,
+				image2:						template(						colors["{offset}" + 5 mod 7] )	,
 												x1: 0.8,		y1: 0
 												x2: 1.55,		y2: 0
 	))}
@@ -771,31 +770,31 @@ stamp_hybrid := [
 												x1: -0.3,		y1: 0
 												x2:  1.3,		y2: 0
 		   )}
-		3: {								template(						colors[2]) }
+		3: {								template(						colors["{offset}" + 2 mod 3] ) }
 		4: { linear_blend(
-				image1:						template(						colors[3])	,
-				image2:						template(						colors[2])	,
+				image1:						template(						colors["{offset}" + 3 mod 4] )	,
+				image2:						template(						colors["{offset}" + 2 mod 4] )	,
 												x1: -0.3,		y1: 0
 												x2:  1.3,		y2: 0
 		)}
-		5: {								template(						colors[3]) }
+		5: {								template(						colors["{offset}" + 3 mod 5] ) }
 		6: { linear_blend(
-				image1:						template(						colors[4])	,
-				image2:						template(						colors[3])	,
+				image1:						template(						colors["{offset}" + 4 mod 6] )	,
+				image2:						template(						colors["{offset}" + 3 mod 6] )	,
 													x1: -0.3,	y1: 0
 													x2:  1.3,	y2: 0
 		   )}
-		7: {								template(						colors[4]) }
+		7: {								template(						colors["{offset}" + 4 mod 7] ) }
 	]
 	horizontal: horizontal_stamp_hybrid
 	vertical: [
 		1: {								template(						colors[0]) }
 		2: {								template(						colors[1]) }
-		3: {								template(						colors[2]) }
-		4: {								template(						colors[3]) }
-		5: {								template(						colors[4]) }
-		6: {								template(						colors[5]) }
-	#	7: {								template(						colors[6]) }
+		3: {								template(						colors["{offset}" + 2 mod 3] ) }
+		4: {								template(						colors["{offset}" + 3 mod 4] ) }
+		5: {								template(						colors["{offset}" + 4 mod 5] ) }
+		6: {								template(						colors["{offset}" + 5 mod 6] ) }
+	#	7: {								template(						colors["{offset}" + 6 mod 7] ) }
 	]
 	overlay: overlay_hybrid
 ]
@@ -870,7 +869,6 @@ color_combination := {
 			dark:							base,
 			mask:								"hybrid_blend_{type}.png",
 		)
-	#	7: {								template(						colors[6]) }
 	else if multi and artifact then
 		masked_blend(
 			light:							masked_blend(
@@ -934,19 +932,19 @@ color_combination := {
 # Specific types
 ########################################################################
 
-card_background		:= { color_background(type:"card",			base_hybrid:card_hybrid)			}
-card_ptbox			:= { color_background(type:"pt",			base_hybrid:pt_hybrid)				}
-flip_ptbox			:= { color_background(type:"pt",			base_hybrid:flip_pt_hybrid)			}
-flip_ptbox2			:= { color_background(type:"pt2",			base_hybrid:flip_pt_hybrid2)		}
-leveler_ptbox		:= { color_background(type:"pt",			base_hybrid:leveler_pt_hybrid)		}
-leveler_ptbox2		:= { color_background(type:"pt",			base_hybrid:leveler_pt_hybrid2)		}
-leveler_ptbox3		:= { color_background(type:"pt",			base_hybrid:leveler_pt_hybrid3)		}
-card_textbox		:= { color_background(type:"textbox",		base_hybrid:textbox_hybrid)			}
-card_typeline		:= { color_background(type:"typeline",		base_hybrid:typeline_hybrid)		}
-card_identity		:= { color_background(type:"identity",		base_hybrid:identity_hybrid)		}
-card_identity_2		:= { color_background(type:"identity2",		base_hybrid:identity_hybrid)		}
-card_stamp			:= { color_background(type:"stamp",			base_hybrid:stamp_hybrid)			}
-card_stamp2			:= { color_background(type:"stamp2",		base_hybrid:stamp_hybrid)			}
+card_background		:= { color_background(type:"card",			base_hybrid:card_hybrid)			}@(offset:0)
+card_ptbox			:= { color_background(type:"pt",			base_hybrid:pt_hybrid)				}@(offset:0)
+flip_ptbox			:= { color_background(type:"pt",			base_hybrid:flip_pt_hybrid)			}@(offset:0)
+flip_ptbox2			:= { color_background(type:"pt2",			base_hybrid:flip_pt_hybrid2)		}@(offset:0)
+leveler_ptbox		:= { color_background(type:"pt",			base_hybrid:leveler_pt_hybrid)		}@(offset:0)
+leveler_ptbox2		:= { color_background(type:"pt",			base_hybrid:leveler_pt_hybrid2)		}@(offset:0)
+leveler_ptbox3		:= { color_background(type:"pt",			base_hybrid:leveler_pt_hybrid3)		}@(offset:0)
+card_textbox		:= { color_background(type:"textbox",		base_hybrid:textbox_hybrid)			}@(offset:0)
+card_typeline		:= { color_background(type:"typeline",		base_hybrid:typeline_hybrid)		}@(offset:0)
+card_identity		:= { color_background(type:"identity",		base_hybrid:identity_hybrid)		}@(offset:0)
+card_identity_2		:= { color_background(type:"identity2",		base_hybrid:identity_hybrid)		}@(offset:0)
+card_stamp			:= { color_background(type:"stamp",			base_hybrid:stamp_hybrid)			}@(offset:0)
+card_stamp2			:= { color_background(type:"stamp2",		base_hybrid:stamp_hybrid)			}@(offset:0)
 
 flip_background := {
 	linear_blend(

--- a/magic-blends.mse-include/new-blends
+++ b/magic-blends.mse-include/new-blends
@@ -5,12 +5,13 @@
 ########################################################################
 # Filenames and other defaults
 ########################################################################
+	include file: mask_names.txt
 
 	mask_hybrid_with_land			:=	{ false }
 	mask_hybrid_with_gold			:=	{ false }
 	mask_multi_land_with_color		:=	{ false }
-	template						:=	{		input								+  "{type}.jpg" }
-	land_template					:=	{ (if	input == "a" then "c" else input)	+ "l{type}.jpg" }
+	template						:=	{  		input								+  "{type}.jpg" }
+	land_template					:=	{ ( if	input == "a" then "c" else input)	+ "l{type}.jpg" }
 
 # For what value should thumbnails of hybrids be made?
 	hybrid_previews					:= "hybrid"
@@ -674,20 +675,20 @@ identity_horizontal_hybrid := [
 		light: masked_blend(
 		light:								template(						colors[0]), 
 		dark:								template(						colors[2]), 
-		mask:									"/magic-identity-new.mse-include/imask_32.png"),
+		mask:									id_mask[32]),
 		dark:								template(						colors[1]), 
-		mask:									"/magic-identity-new.mse-include/imask_33.png"
+		mask:									id_mask[33]
 		)}
 	4: {masked_blend(
 		light: masked_blend(
 			light: masked_blend(
 				light:						template(						colors[1]), 
 				dark:						template(						colors[0]),
-				mask:							"/magic-identity-new.mse-include/imask_42.png" ),
+				mask:							id_mask[42] ),
 			dark:							template(						colors[2]),
-			mask:								"/magic-identity-new.mse-include/imask_43.png" ),
+			mask:								id_mask[43] ),
 		dark:								template(						colors[3]),
-		mask:									"/magic-identity-new.mse-include/imask_44.png"
+		mask:									id_mask[44]
 		)}
 	5: {masked_blend(
 		light: masked_blend(
@@ -695,13 +696,13 @@ identity_horizontal_hybrid := [
 				light: masked_blend(
 					light:					template(						colors[0]),
 					dark:					template(						colors[4]),
-					mask:						"/magic-identity-new.mse-include/imask_52.png"),
+					mask:						id_mask[52]),
 				dark:						template(						colors[1]),
-				mask:							"/magic-identity-new.mse-include/imask_53.png"),
+				mask:							id_mask[53]),
 			dark:							template(						colors[2]),
-			mask:								"/magic-identity-new.mse-include/imask_54.png"),
+			mask:								id_mask[54]),
 		dark:								template(						colors[3]),
-		mask:									"/magic-identity-new.mse-include/imask_55.png")
+		mask:									id_mask[55])
 		}
 	6: {									template(						"m") }
 

--- a/magic-blends.mse-include/new-blends
+++ b/magic-blends.mse-include/new-blends
@@ -60,8 +60,8 @@ hybrid_color := {
 ########################################################################
 
 card_hybrid_2 := {linear_blend(
-					image1:					template(						colors[0])
-					image2:					template(						colors[1])
+					image1:					template(						colors[0])	,
+					image2:					template(						colors[1])	,
 												x1: 0.4,		y1: 0
 												x2: 0.6,		y2: 0
 	)
@@ -70,8 +70,8 @@ card_hybrid_2 := {linear_blend(
 overlay_hybrid := [
 	1: {									template(						colors[0])}
 	2: {combine_blend(
-			image1: 						template(						colors[0]),
-			image2: 						template(						colors[1]),
+			image1: 						template(						colors[0])	,
+			image2: 						template(						colors[1])	,
 			combine: "symmetric overlay"
 	)}
 ]
@@ -86,104 +86,104 @@ vertical_card_hybrid	:= {
 
 
 horizontal_card_hybrid := [
-	1:	{ 									template(						colors[0])
-	}
-
-	2:	card_hybrid_2
+	1:	{ 									template(						colors[0])}
+	2:										card_hybrid_2
 
 	3: {linear_blend(
-			image1:							template(						colors[0])
+			image1:							template(						colors[0])	,
 												x1: 0.22,		y1: 0
 												x2: 0.4,		y2: 0
 			image2: linear_blend(
-				image1:						template(						colors[1])
+				image1:						template(						colors[1])	,
+				image2: 					template(						colors[2])	,
 												x1: 0.6,		y1: 0
 												x2: 0.78,		y2: 0
-				image2: 					template(						colors[2])
-	))}
+			)
+		)
+	}
 
 	4: {linear_blend(
-			image1:							template(						colors[0])
+			image1:							template(						colors[0])	,
 												x1: 0.15,		y1: 0
 												x2: 0.31,		y2: 0
 			image2: linear_blend(
-				image1:						template(						colors[1])
+				image1:						template(						colors[1])	,
 												x1: 0.42,		y1: 0
 												x2: 0.58,		y2: 0
 				image2: linear_blend(
-					image1:					template(						colors[2])
+					image1:					template(						colors[2])	,
+					image2:					template(						colors[3])	,
 												x1: 0.69,		y1: 0
 												x2: 0.85,		y2: 0
-					image2:					template(						colors[3])
 	)))}
 
 	5: {linear_blend(
-			image1: 						template(						colors[0])
+			image1: 						template(						colors[0])	,
 												x1:  2.0 / 15,	y1: 0
 												x2:  4.0 / 15,	y2: 0
 			image2: linear_blend(
-				image1: 					template(						colors[1])
+				image1: 					template(						colors[1])	,
 												x1:  5.0 / 15,	y1: 0
 												x2:  7.0 / 15,	y2: 0
 				image2: linear_blend(
-					image1: 				template(						colors[2])
+					image1: 				template(						colors[2])	,
 												x1:  8.0 / 15,	y1: 0
 												x2: 10.0 / 15,	y2: 0
 					image2: linear_blend(
-						image1:				template(						colors[3])
+						image1:				template(						colors[3])	,
+						image2:				template(						colors[4])	,
 												x1: 11.0 / 15,	y1: 0
 												x2: 13.0 / 15,	y2: 0
-						image2:				template(						colors[4])
 	))))}
 
 	6: {linear_blend(
-			image1:							template(						colors[0])
+			image1:							template(						colors[0])	,
 												x1:  1.5 / 15,	y1: 0
 												x2:  3.1 / 15,	y2: 0
 			image2: linear_blend(
-				image1:						template(						colors[1])
+				image1:						template(						colors[1])	,
 												x1:  4.1 / 15,	y1: 0
 												x2:  5.7 / 15,	y2: 0
 				image2: linear_blend(
-					image1:					template(						colors[2])
+					image1:					template(						colors[2])	,
 												x1:  6.7 / 15,	y1: 0
 												x2:  8.3 / 15,	y2: 0
 					image2: linear_blend(
-						image1:				template(						colors[3])
+						image1:				template(						colors[3])	,
 												x1:  9.3 / 15,	y1: 0
 												x2: 10.9 / 15,	y2: 0
 						image2: linear_blend(
-							image1:			template(						colors[4])
+							image1:			template(						colors[4])	,
+							image2:			template(						colors[5])	,
 												x1: 11.9 / 15,	y1: 0
 												x2: 13.5 / 15,	y2: 0
-							image2:			template(						colors[5])
 	)))))}
 
 	7: {linear_blend(
-			image1:							template(						colors[0])
+			image1:							template(						colors[0])	,
 												x1:  1.3 / 15,	y1: 0
 												x2:  2.7 / 15,	y2: 0
 			image2: linear_blend(
-				image1:						template(						colors[1])
+				image1:						template(						colors[1])	,
 												x1:  3.5 / 15,	y1: 0
 												x2:  4.9 / 15,	y2: 0
 				image2: linear_blend(
-					image1:					template(						colors[2])
+					image1:					template(						colors[2])	,
 												x1:  5.7 / 15,	y1: 0
 												x2:  7.1 / 15,	y2: 0
 					image2: linear_blend(
-						image1:				template(						colors[3])
+						image1:				template(						colors[3])	,
 												x1:  7.9 / 15,	y1: 0
 												x2:  9.3 / 15,	y2: 0
 						image2: linear_blend(
-							image1:			template(						colors[4])
+							image1:			template(						colors[4])	,
 												x1: 10.1 / 15,	y1: 0
 												x2: 11.5 / 15,	y2: 0
 							image2: linear_blend(
-								image1:		template(						colors[5])
+								image1:		template(						colors[5])	,
+								image2:		template(						colors[6])	,
 												x1: 12.3 / 15,	y1: 0
 												x2: 13.7 / 15,	y2: 0
-								image2:		template(						colors[6])
 		))))))}
 ]
 
@@ -197,39 +197,39 @@ card_hybrid := [
 		2:	card_hybrid_2
 
 		3:{linear_blend(
-			image1: 						card_hybrid_2(					colors: colors[0] + colors[1]),
-			image2: 						template(						colors[2]),
+			image1: 						card_hybrid_2(					colors: colors[0] + colors[1]	)	,
+			image2: 						template(						colors[2]						)	,
 												x1: 0,			y1: 0.55
 												x2: 0,			y2: 0.77
 		)}
 
 		4:{linear_blend(
-			image1:							card_hybrid_2(					colors: colors[0] + colors[1])
-			image2: 						card_hybrid_2(					colors: colors[3] + colors[2])
+			image1:							card_hybrid_2(					colors: colors[0] + colors[1]	)	,
+			image2: 						card_hybrid_2(					colors: colors[3] + colors[2]	)	,
 												x1: 0,			y1: 0.4
 												x2: 0,			y2: 0.62
 		)}
 
 		5: {linear_blend(
 				image1: linear_blend(
-					image1:					card_hybrid_2(					colors: colors[0] + colors[1]),
-					image2:					card_hybrid_2(					colors: colors[4] + colors[2]),
+					image1:					card_hybrid_2(					colors: colors[0] + colors[1]	)	,
+					image2:					card_hybrid_2(					colors: colors[4] + colors[2]	)	,
 												x1: 0,			y1: 0.19
 												x2: 0,			y2: 0.35
-			),
-				image2:						template(colors[3]),
+				),
+				image2:						template(						colors[3]						)	,
 												x1: 0,			y1: 0.777
 												x2: 0,			y2: 0.937
 		)}
 
 		6: {linear_blend(
 				image1: linear_blend(
-					image1:					card_hybrid_2(					colors: colors[0] + colors[1]),
-					image2:					card_hybrid_2(					colors: colors[5] + colors[2]),
+					image1:					card_hybrid_2(					colors: colors[0] + colors[1]	)	,
+					image2:					card_hybrid_2(					colors: colors[5] + colors[2]	)	,
 												x1: 0,			y1: 0.19
 												x2: 0,			y2: 0.35
 				),
-				image2:						card_hybrid_2(					colors: colors[4] + colors[3]),
+				image2:						card_hybrid_2(					colors: colors[4] + colors[3]	)	,
 												x1: 0,			y1: 0.777
 												x2: 0,			y2: 0.937
 		)}
@@ -237,16 +237,16 @@ card_hybrid := [
 		7: {linear_blend(
 				image1: linear_blend(
 					image1: linear_blend(
-						image1:				card_hybrid_2(					colors: colors[0] + colors[1]),
-						image2:				card_hybrid_2(					colors: colors[6] + colors[3]),
+						image1:				card_hybrid_2(					colors: colors[0] + colors[1]	)	,
+						image2:				card_hybrid_2(					colors: colors[6] + colors[3]	)	,
 												x1: 0,			y1: 0.34
 												x2: 0,			y2: 0.50
 					),
-					image2:					card_hybrid_2(					colors: colors[5] + colors[3]),
+					image2:					card_hybrid_2(					colors: colors[5] + colors[3]	)	,
 												x1: 0,			y1: 0.877
 												x2: 0,			y2: 0.937
 				),
-				image2:						template(						colors[4]),
+				image2:						template(						colors[4]						)	,
 												x1: 0,			y1: 1.140
 												x2: 0,			y2: 1.300
 		   )}
@@ -255,8 +255,8 @@ card_hybrid := [
 	vertical:		[
 		1: { 								template(						colors[0]) }
 		2: { linear_blend(
-				image1:						template(						colors[0])
-				image2:						template(						colors[1])
+				image1:						template(						colors[0])	,
+				image2:						template(						colors[1])	,
 												x1: 0,			y1: 0.4
 												x2: 0,			y2: 0.6
 		)}
@@ -280,33 +280,33 @@ horizontal_pt_hybrid := [
 	1: {									template(						colors[0]) }
 	2: {									template(						colors[1]) }
 	3: { linear_blend(
-			image1:							template(						colors[1])
-			image2:							template(						colors[2])
+			image1:							template(						colors[1])	,
+			image2:							template(						colors[2])	,
 												x1: -0.51,		y1: 0
 												x2:  0.26,		y2: 0
-	   )}
+	)}
 	4: { linear_blend(
-			image1:							template(						colors[2])
-			image2:							template(						colors[3])
+			image1:							template(						colors[2])	,
+			image2:							template(						colors[3])	,
 												x1: -0.1,		y1: 0
 												x2:  0.6,		y2: 0
-	   )}
+	)}
 	5: { linear_blend(
-			image1:							template(						colors[3])
-			image2:							template(						colors[4])
+			image1:							template(						colors[3])	,
+			image2:							template(						colors[4])	,
 												x1: 0.08,		y1: 0
 												x2: 0.65,		y2: 0
-	   )}
+	)}
 	6: { linear_blend(
-			image1:							template(						colors[4])
-			image2:							template(						colors[5])
+			image1:							template(						colors[4])	,
+			image2:							template(						colors[5])	,
 												x1: 0.07,		y1: 0
 												x2: 0.7,		y2: 0
-	   )}
+	)}
 	7: {linear_blend(
 			image1: linear_blend(
-				image1:						template(						colors[4]),
-				image2:						template(						colors[5]),
+				image1:						template(						colors[4])	,
+				image2:						template(						colors[5])	,
 												x1: -0.2,		y1: 0
 												x2:  0.2,		y2: 0
 			),
@@ -325,17 +325,17 @@ pt_hybrid := [
 		3: {								template(						colors[2])	}
 		4: {								template(						colors[2])	}
 		5: { linear_blend(
-				image1:						template(						colors[2])
-				image2:						template(						colors[3])
+				image1:						template(						colors[2])	,
+				image2:						template(						colors[3])	,
 												x1: 0,		y1: -1.5
 												x2: 0,		y2:  0.7
-		   )}
+		)}
 		6: { linear_blend(
-				image1:						template(						colors[2])
-				image2:						template(						colors[3])
+				image1:						template(						colors[2])	,
+				image2:						template(						colors[3])	,
 												x1: 0,			y1: -1.5
 												x2: 0,			y2:  0.7
-		   )}
+		)}
 		7: {								template(						colors[4]) }
 	]
 	horizontal: horizontal_pt_hybrid
@@ -363,14 +363,14 @@ flip_pt_hybrid := [
 		3: {								template(						colors[1])	}
 		4: {								template(						colors[1])	}
 		5: {linear_blend(
-				image1:						template(						colors[1])
-				image2:						template(						colors[2])
+				image1:						template(						colors[1])	,
+				image2:						template(						colors[2])	,
 												x1: 0,			y1: -1
 												x2: 0,			y2:  1.8
 		)}
 		6: { linear_blend(
-				image1:						template(						colors[1])
-				image2:						template(						colors[2])
+				image1:						template(						colors[1])	,
+				image2:						template(						colors[2])	,
 												x1: 0,			y1: -1
 												x2: 0,			y2:  1.8
 		)}
@@ -381,20 +381,20 @@ flip_pt_hybrid := [
 		1: {								template(						colors[0]) }
 		2: {								template(						colors[0]) }
 		3: { linear_blend(
-				image1:						template(						colors[0])
-				image2:						template(						colors[1])
+				image1:						template(						colors[0])	,
+				image2:						template(						colors[1])	,
 												x1: 0,			y1: 0
 												x2: 0,			y2: 2
 		)}
 		4: { linear_blend(
-				image1:						template(						colors[0])
-				image2:						template(						colors[1])
+				image1:						template(						colors[0])	,
+				image2:						template(						colors[1])	,
 												x1: 0,		y1: -1.5
 												x2: 0,		y2:  1
-		   )}
+		)}
 		5: { linear_blend(
-				image1:						template(						colors[0])
-				image2:						template(						colors[1])
+				image1:						template(						colors[0])	,
+				image2:						template(						colors[1])	,
 												x1: 0,			y1: -1.1
 												x2: 0,			y2:  0.2
 		)}
@@ -410,11 +410,11 @@ flip_pt_hybrid2 := [
 		1: {								template(						colors[0]) }
 		2: {								template(						colors[0]) }
 		3: { linear_blend(
-				image1:						template(						colors[0])
-				image2:						template(						colors[2])
+				image1:						template(						colors[0])	,
+				image2:						template(						colors[2])	,
 												x1: 0,			y1: -1
 												x2: 0,			y2:  1.1
-		   )}
+		)}
 		4: {								template(						colors[3]) }
 		5: {								template(						colors[4]) }
 		6: {								template(						colors[5]) }
@@ -425,17 +425,17 @@ flip_pt_hybrid2 := [
 		2: {								template(						colors[0]) }
 		3: {								template(						colors[0]) }
 		4: { linear_blend(
-				image1:						template(						colors[0])
-				image2:						template(						colors[1])
+				image1:						template(						colors[0])	,
+				image2:						template(						colors[1])	,
 												x1: 0.4,		y1: 0
 												x2: 1.5,		y2: 0
-		   )}
+		)}
 		5: { linear_blend(
-				image1:						template(						colors[0])
-				image2:						template(						colors[1])
+				image1:						template(						colors[0])	,
+				image2:						template(						colors[1])	,
 												x1: 0.08,		y1: 0
 												x2: 0.65,		y2: 0
-		   )}
+		)}
 		6: {								template(						colors[5]) } #TODO
 		7: {								template(						colors[6]) } #TODO
 	]
@@ -443,17 +443,17 @@ flip_pt_hybrid2 := [
 		1: {								template(						colors[0]) }
 		2: {								template(						colors[1]) }
 		3: { linear_blend(
-				image1:						template(						colors[1])
-				image2:						template(						colors[2])
+				image1:						template(						colors[1])	,
+				image2:						template(						colors[2])	,
 												x1: 0,			y1: -1
 												x2: 0,			y2:  1.5
-		   )}
+		)}
 		4: { linear_blend(
-				image1:						template(						colors[2])
-				image2:						template(						colors[3])
+				image1:						template(						colors[2])	,
+				image2:						template(						colors[3])	,
 												x1: 0,			y1: 0.5
 												x2: 0,			y2: 3
-		   )}
+		)}
 		5: {								template(						colors[3]) }
 		6: {								template(						colors[5]) } # Probably not right
 		7: {								template(						colors[6]) }
@@ -472,11 +472,11 @@ leveler_pt_hybrid := [
 		1: {								template(						colors[0]) }
 		2: {								template(						colors[1]) }
 		3: { linear_blend(
-				image1:						template(						colors[1])
-				image2:						template(						colors[2])
+				image1:						template(						colors[1])	,
+				image2:						template(						colors[2])	,
 												x1: 0,			y1: 0
 												x2: 0,			y2: 1
-		   )}
+		)}
 		4: {								template(						colors[2]) }
 		5: {								template(						colors[2]) }
 		6: {								template(						colors[2]) }
@@ -487,16 +487,16 @@ leveler_pt_hybrid := [
 		1: {								template(						colors[0]) }
 		2: {								template(						colors[1]) }
 		3: { linear_blend(
-				image1:						template(						colors[1])
-				image2:						template(						colors[2])
+				image1:						template(						colors[1])	,
+				image2:						template(						colors[2])	,
 												x1: 0,			y1: 0
 												x2: 0,			y2: 1
 		)}
 		4: {								template(						colors[2]) }
 		5: {								template(						colors[3]) }
 		6: { linear_blend(
-				image1:						template(						colors[3])
-				image2:						template(						colors[4])
+				image1:						template(						colors[3])	,
+				image2:						template(						colors[4])	,
 												x1: 0,			y1: 0
 												x2: 0,			y2: 0.25
 		)}
@@ -547,14 +547,14 @@ leveler_pt_hybrid3 := [
 		3: {								template(						colors[2]) }
 		4: {								template(						colors[2]) }
 		5: { linear_blend(
-				image1:						template(						colors[2])
-				image2:						template(						colors[3])
+				image1:						template(						colors[2])	,
+				image2:						template(						colors[3]	,)
 												x1: 0,			y1: 0
 												x2: 0,			y2: 1
 		   )}
 		6: { linear_blend(
-				image1:						template(						colors[2])
-				image2:						template(						colors[3])
+				image1:						template(						colors[2])	,
+				image2:						template(						colors[3])	,
 												x1: 0,			y1: 0
 												x2: 0,			y2: 1
 		   )}
@@ -567,14 +567,14 @@ leveler_pt_hybrid3 := [
 		3: {								 template(						colors[2]) }
 		4: {								 template(						colors[3]) }
 		5: { linear_blend(
-				image1:						template(						colors[3])
-				image2:						template(						colors[4])
+				image1:						template(						colors[3])	,
+				image2:						template(						colors[4])	,
 												x1: 0,			y1: 0
 												x2: 0,			y2: 0.5
 		   )}
 		6: { linear_blend(
-				image1:						template(						colors[4])
-				image2:						template(						colors[5])
+				image1:						template(						colors[4])	,
+				image2:						template(						colors[5])	,
 												x1: 0,			y1: 0
 												x2: 0,			y2: 0.5
 		   )}
@@ -622,8 +622,8 @@ identity_horizontal_hybrid := [
 	0: {									template(						"c") }
 	1: {									template(						colors[0]) }
 	2: {linear_blend(
-			image1:							template(						colors[0])
-			image2:							template(						colors[1])
+			image1:							template(						colors[0])	,
+			image2:							template(						colors[1])	,
 												x1: 0.49,		y1: 0.49
 												x2: 0.5,		y2: 0.5
 	   )}
@@ -679,44 +679,44 @@ identity_hybrid := [
 horizontal_stamp_hybrid := [
 	1: {									template(						colors[0]) }
 	2: { linear_blend(
-			image1:							template(						colors[0])
-			image2:							template(						colors[1])
+			image1:							template(						colors[0])	,
+			image2:							template(						colors[1])	,
 												x1: -0.3,		y1: 0
 												x2:  1.3,		y2: 0
-	   )}
+	)}
 	3: {									template(						colors[1]) }
 	4: { linear_blend(
-			image1:							template(						colors[1])
-			image2:							template(						colors[2])
+			image1:							template(						colors[1])	,
+			image2:							template(						colors[2])	,
 												x1: -0.3,		y1: 0
 												x2:  1.3,		y2: 0
-	   )}
+	)}
 	5: {linear_blend(
 			image1:							template(						colors[1])
 												x1: -0.55,		y1: 0
 												x2:  0.2,		y2: 0
 			image2: linear_blend(
-				image1:						template(						colors[2])
-				image2:						template(						colors[3])
+				image1:						template(						colors[2])	,
+				image2:						template(						colors[3])	,
 												x1: 0.8,		y1: 0
 												x2: 1.55,		y2: 0
-	   ))}
+	))}
 	6: { linear_blend(
-			image1:							template(						colors[2])
-			image2:							template(						colors[3])
+			image1:							template(						colors[2])	,
+			image2:							template(						colors[3])	,
 												x1: 0.1,		y1: 0
 												x2: 0.9,		y2: 0
-	   )}
+	)}
 	7: {linear_blend(
-			image1:							template(						colors[2])
+			image1:							template(						colors[2])	,
 												x1: -0.55,		y1: 0
 												x2:  0.2,		y2: 0
 			image2: linear_blend(
-				image1:						template(						colors[3])
-				image2:						template(						colors[4])
+				image1:						template(						colors[3])	,
+				image2:						template(						colors[4])	,
 												x1: 0.8,		y1: 0
 												x2: 1.55,		y2: 0
-	   ))}
+	))}
 ]
 
 stamp_hybrid := [
@@ -724,22 +724,22 @@ stamp_hybrid := [
 		0: {								template(						"c")       }
 		1: {								template(						colors[0]) }
 		2: { linear_blend(
-				image1:						template(						colors[0])
-				image2:						template(						colors[1])
+				image1:						template(						colors[0])	,
+				image2:						template(						colors[1])	,
 												x1: -0.3,		y1: 0
 												x2:  1.3,		y2: 0
 		   )}
 		3: {								template(						colors[2]) }
 		4: { linear_blend(
-				image1:						template(						colors[3])
-				image2:						template(						colors[2])
+				image1:						template(						colors[3])	,
+				image2:						template(						colors[2])	,
 												x1: -0.3,		y1: 0
 												x2:  1.3,		y2: 0
-		   )}
+		)}
 		5: {								template(						colors[3]) }
 		6: { linear_blend(
-				image1:						template(						colors[4])
-				image2:						template(						colors[3])
+				image1:						template(						colors[4])	,
+				image2:						template(						colors[3])	,
 													x1: -0.3,	y1: 0
 													x2:  1.3,	y2: 0
 		   )}

--- a/magic-blends.mse-include/new-blends
+++ b/magic-blends.mse-include/new-blends
@@ -351,6 +351,7 @@ pt_hybrid := [
 	overlay: overlay_hybrid
 ]
 
+
 ########################################################################
 # P/T boxes of flip cards
 ########################################################################
@@ -460,7 +461,48 @@ flip_pt_hybrid2 := [
 	]
 	overlay: overlay_hybrid
 ]
+	########################################################################
+# P/T boxes for leveler cards
+########################################################################
 
+leveler_pt_hybrid := [
+	radial: [
+		0: {								template(						"c")       }
+		1: {								template(						colors[0]) }
+		2: {								template(						colors[1]) }
+		3: { linear_blend(
+				image1:						template(						colors[1])	,
+				image2:						template(						colors[2])	,
+												x1: 0,			y1: 0
+												x2: 0,			y2: 1
+		)}
+		4: {								template(						colors[2]) }
+		5: {								template(						colors[2]) }
+		6: {								template(						colors[2]) }
+		7: {								template(						colors[4]) }
+	]
+	horizontal: horizontal_pt_hybrid
+	vertical: [
+		1: {								template(						colors[0]) }
+		2: {								template(						colors[1]) }
+		3: { linear_blend(
+				image1:						template(						colors[1])	,
+				image2:						template(						colors[2])	,
+												x1: 0,			y1: 0
+												x2: 0,			y2: 1
+		)}
+		4: {								template(						colors[2]) }
+		5: {								template(						colors[3]) }
+		6: { linear_blend(
+				image1:						template(						colors[3])	,
+				image2:						template(						colors[4])	,
+												x1: 0,			y1: 0
+												x2: 0,			y2: 0.25
+		)}
+		7: {								template(						colors[5]) }
+	]
+	overlay: overlay_hybrid
+]
 
 ########################################################################
 # P/T boxes for leveler cards
@@ -583,6 +625,7 @@ leveler_pt_hybrid3 := [
 	overlay: overlay_hybrid
 ]
 
+
 ########################################################################
 # Textbox and typeline for FPM templates and Futureshifts
 ########################################################################
@@ -633,17 +676,16 @@ identity_horizontal_hybrid := [
 		dark:								template(						colors[2]), 
 		mask:									"/magic-identity-new.mse-include/imask_32.png"),
 		dark:								template(						colors[1]), 
-		mask:									"/magic-identity-new.mse-include/imask_33.png")}
+		mask:									"/magic-identity-new.mse-include/imask_33.png"
+		)}
 	4: {masked_blend(
 		light: masked_blend(
 			light: masked_blend(
 				light:						template(						colors[1]), 
 				dark:						template(						colors[0]),
-				mask:							"/magic-identity-new.mse-include/imask_42.png"
-			),
+				mask:							"/magic-identity-new.mse-include/imask_42.png" ),
 			dark:							template(						colors[2]),
-			mask:								"/magic-identity-new.mse-include/imask_43.png"
-			)
+			mask:								"/magic-identity-new.mse-include/imask_43.png" ),
 		dark:								template(						colors[3]),
 		mask:									"/magic-identity-new.mse-include/imask_44.png"
 		)}
@@ -670,7 +712,6 @@ identity_hybrid := [
 	horizontal:		identity_horizontal_hybrid
 	overlay:		identity_horizontal_hybrid
 ]
-
 ########################################################################
 # Promo Stamp
 ########################################################################
@@ -757,7 +798,6 @@ stamp_hybrid := [
 	]
 	overlay: overlay_hybrid
 ]
-
 ########################################################################
 # Putting it all together.
 ########################################################################


### PR DESCRIPTION
Allows cards with three or more colors to have which one acts like the first item in the collection.
The default value (an offset of zero), renders the card as normal. For each increase in the offset, the colors rotate one position forwards.
For example, if RWB, GWUB, and WUBRG are the default ways of rendering, then an offset of one will cause them to render WUR, WUBG, and UBRGW respsectively. 
Because is functionality is based on the mod function, an offset greater than the number of colors on the card will not an error, but will instead loop the card back around.

The functionality has been implemented in a way that is hopefully easy to hook into from styles; but because I'm bad at version management, I don't really have a style I can test hooking into at the moment.